### PR TITLE
Use ib.sleep instead of time.sleep

### DIFF
--- a/tech_signals_ibkr.py
+++ b/tech_signals_ibkr.py
@@ -336,12 +336,12 @@ for tk in iterable:
                     ib.reqMktData(con, "101,106", False, False)   # 101=openInt,106=impVol
                 except Exception:
                     continue    # silently skip rejects
-            time.sleep(3.0)   # give snapshots time to populate
+            ib.sleep(3.0)     # give snapshots time to populate while allowing the event loop to run
             # Cancel streaming to avoid dangling subscriptions
             for con in qual:
                 ib.cancelMktData(con)
             # Allow IB gateway a brief breather to clear errors
-            time.sleep(0.5)
+            ib.sleep(0.5)
 
             # collect IV & OI
             iv_now = np.nan
@@ -444,7 +444,7 @@ for tk in iterable:
                      beta_SPY=beta, ADV30=ADV30,
                      next_earnings=earn_dt, OI_near_ATM=oi_near))
 
-    time.sleep(0.25)
+    ib.sleep(0.25)
 
 pd.DataFrame(rows).to_csv(OUTPUT_CSV,index=False)
 logging.info("Saved %d rows → %s", len(rows), OUTPUT_CSV)

--- a/tests/test_historic_prices.py
+++ b/tests/test_historic_prices.py
@@ -300,12 +300,12 @@ for tk in iterable:
                     ib.reqMktData(con, "101,106", False, False)   # 101=openInt,106=impVol
                 except Exception:
                     continue    # silently skip rejects
-            time.sleep(3.0)   # give snapshots time to populate
+            ib.sleep(3.0)   # give snapshots time to populate
             # Cancel streaming to avoid dangling subscriptions
             for con in qual:
                 ib.cancelMktData(con)
             # Allow IB gateway a brief breather to clear errors
-            time.sleep(0.5)
+            ib.sleep(0.5)
 
             # collect IV & OI
             iv_now = np.nan
@@ -374,7 +374,7 @@ for tk in iterable:
                      beta_SPY=beta, ADV30=ADV30,
                      next_earnings=earn_dt, OI_near_ATM=oi_near))
 
-    time.sleep(0.25)
+    ib.sleep(0.25)
 
 pd.DataFrame(rows).to_csv(OUTPUT_CSV,index=False)
 logging.info("Saved %d rows → %s", len(rows), OUTPUT_CSV)


### PR DESCRIPTION
## Summary
- use `ib.sleep` instead of `time.sleep` in `tech_signals_ibkr.py`
- keep `tests/test_historic_prices.py` in sync

## Testing
- `pytest -q` *(fails: command not found)*