### PR TITLE
Add pandas_datareader requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pip install -r requirements.txt
 ```
 
 The scripts require Python 3.11+ and the packages listed in `requirements.txt`.
+`pandas_datareader` is needed for downloading FRED data in `live_feed.py`.
 
 ## Usage Examples
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 numpy
 ib_insync
 tqdm
+pandas_datareader


### PR DESCRIPTION
## Summary
- add `pandas_datareader` to requirements
- note the new dependency in the README install section

## Testing
- `pytest -q` *(fails: command not found)*