### PR TITLE
Improve optional dependency handling in tests

### DIFF
--- a/tests/test_historic_prices.py
+++ b/tests/test_historic_prices.py
@@ -1,6 +1,10 @@
 import unittest
 from unittest.mock import patch
-import pandas as pd
+
+try:  # optional dependency
+    import pandas as pd
+except Exception as e:  # pragma: no cover - skip if pandas missing
+    raise unittest.SkipTest("pandas is not installed") from e
 
 
 import historic_prices as hp

--- a/tests/test_option_chain_snapshot.py
+++ b/tests/test_option_chain_snapshot.py
@@ -1,7 +1,35 @@
+import sys
+import types
 import unittest
 from datetime import datetime, timedelta
 
-import option_chain_snapshot as oc
+# Provide minimal stubs so import works without optional packages
+try:
+    import pandas  # noqa: F401
+except Exception:
+    pd_stub = types.ModuleType("pandas")
+    pd_stub.DataFrame = type("DataFrame", (), {})
+    sys.modules.setdefault("pandas", pd_stub)
+
+try:
+    import numpy  # noqa: F401
+except Exception:
+    np_stub = types.ModuleType("numpy")
+    np_stub.nan = float("nan")
+    np_stub.isnan = lambda x: x != x
+    sys.modules.setdefault("numpy", np_stub)
+
+try:
+    import ib_insync  # noqa: F401
+except Exception:
+    ib_stub = types.ModuleType("ib_insync")
+    for cls in ["IB", "Option", "Stock"]:
+        setattr(ib_stub, cls, type(cls, (), {}))
+    sys.modules.setdefault("ib_insync", ib_stub)
+
+import importlib
+
+oc = importlib.import_module("option_chain_snapshot")
 
 class ChooseExpiryTests(unittest.TestCase):
     def test_weekly_within_seven_days(self):

--- a/tests/test_portfolio_greeks.py
+++ b/tests/test_portfolio_greeks.py
@@ -3,7 +3,12 @@ import types
 import importlib
 import math
 import unittest
-import pandas as pd
+
+try:  # optional deps
+    import pandas as pd
+    import numpy as np  # noqa: F401
+except Exception as e:  # pragma: no cover - skip if missing
+    raise unittest.SkipTest("pandas/numpy is not installed") from e
 
 # Provide minimal ib_insync stub for module import
 ib_mod = types.ModuleType('ib_insync')


### PR DESCRIPTION
## Summary
- allow `historic_prices` tests to skip when pandas is missing
- stub optional dependencies for option chain snapshot tests
- skip portfolio greeks tests when numpy or pandas aren't installed

## Testing
- `pytest -q`