### PR TITLE
Add time tags to output filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ connectivity.
 | `live_feed.py` | Takes a snapshot of real‑time quotes for tickers listed in `tickers_live.txt` (falling back to `tickers.txt`). Quotes are pulled from IBKR when available, otherwise from yfinance and FRED. Results are written to `live_quotes_YYYYMMDD_HHMM.csv`. |
 | `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest and near‑ATM implied volatility. |
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
-| `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD>.csv` and a totals file. |
+| `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. |
 | `option_chain_snapshot.py` | Saves a complete IBKR option chain to CSV for the entire portfolio or specified symbols, handling live and delayed data automatically. |
 | `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. |
 

--- a/historic_prices.py
+++ b/historic_prices.py
@@ -41,12 +41,15 @@ def _tickers_from_ib() -> list[str]:
 
 PORTFOLIO_FILES = ["tickers_live.txt", "tickers.txt"]      # first existing file wins
 
- # Timestamped output (date only, UTC)
+# Timestamped output (UTC). Includes time so repeated runs don't overwrite.
 DATE_TAG = datetime.utcnow().strftime("%Y%m%d")
+TIME_TAG = datetime.utcnow().strftime("%H%M")
 # Save to iCloud Drive ▸ Downloads
 OUTPUT_DIR = "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/Downloads"
 os.makedirs(OUTPUT_DIR, exist_ok=True)
-OUTPUT_CSV = os.path.join(OUTPUT_DIR, f"historic_prices_{DATE_TAG}.csv")
+OUTPUT_CSV = os.path.join(
+    OUTPUT_DIR, f"historic_prices_{DATE_TAG}_{TIME_TAG}.csv"
+)
 
 def load_tickers() -> list[str]:
     """Return unique tickers prioritising IBKR holdings; otherwise text file."""

--- a/net_liq_history_export.py
+++ b/net_liq_history_export.py
@@ -7,7 +7,7 @@ net_liq_history_export.py  –  Export end-of-day Net-Liq / equity curve
 • If not present – or if you pass  --cp-download  – it pulls the same data
   from IBKR Client-Portal > PortfolioAnalyst (“Performance – Time Weighted”).
 • Writes a cleaned CSV into the standard iCloud Downloads folder:
-      net_liq_history_<YYYYMMDD-YYYYMMDD>.csv
+      net_liq_history_<YYYYMMDD-YYYYMMDD_HHMM>.csv
 • With  --plot  it also drops a PNG equity-curve chart beside the CSV.
 
 Usage
@@ -38,6 +38,7 @@ OUTPUT_DIR = Path(
     "com~apple~CloudDocs/Downloads"
 )
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+TIME_TAG = datetime.utcnow().strftime("%H%M")
 
 # ---  1️⃣  where TWS writes dailyNetLiq.csv -----------------
 # If you changed the “Export Directory” in TWS, edit here OR
@@ -107,7 +108,7 @@ def _filter_range(df: pd.DataFrame, start: str | None, end: str | None) -> pd.Da
     return df
 
 def _save_csv(df: pd.DataFrame, start_label: str, end_label: str) -> Path:
-    out_name = f"net_liq_history_{start_label}-{end_label}.csv"
+    out_name = f"net_liq_history_{start_label}-{end_label}_{TIME_TAG}.csv"
     out_path = OUTPUT_DIR / out_name
     df.to_csv(out_path, index_label="date", quoting=csv.QUOTE_MINIMAL, float_format="%.2f")
     return out_path

--- a/option_chain_snapshot.py
+++ b/option_chain_snapshot.py
@@ -360,7 +360,7 @@ def main():
     logger.info("Symbols: %s", ", ".join(symbols))
     iterable = tqdm(symbols, desc="Option snapshots") if PROGRESS else symbols
 
-    date_tag = datetime.utcnow().strftime("%Y%m%d")
+    date_tag = datetime.utcnow().strftime("%Y%m%d_%H%M")
     combined = []
     for sym in iterable:
         try:

--- a/portfolio_greeks.py
+++ b/portfolio_greeks.py
@@ -8,8 +8,8 @@ portfolio_greeks.py  –  Export per-position option Greeks and account-level to
 • Computes *exposure* greeks → raw greek × contract multiplier × position size
   so that numbers reflect portfolio impact (e.g. Delta $ equivalent).
 • Produces **two** CSV files in the same Downloads folder used by the other tools:
-    1. portfolio_greeks_<YYYYMMDD>.csv          – one row per contract / underlying.
-    2. portfolio_greeks_totals_<YYYYMMDD>.csv   – a single row with summed totals.
+    1. portfolio_greeks_<YYYYMMDD_HHMM>.csv          – one row per contract / underlying.
+    2. portfolio_greeks_totals_<YYYYMMDD_HHMM>.csv   – a single row with summed totals.
 
 Usage
 =====
@@ -371,7 +371,7 @@ def main() -> None:
     dar_99, cdar_99 = eddr(nav_series, horizon_days=252, alpha=0.99)
     logger.info(f"EDDR computed – DaR₉₉: {dar_99:.4%},  CDaR₉₉: {cdar_99:.4%}")
 
-    date_tag = ts_utc.strftime("%Y%m%d")
+    date_tag = ts_utc.strftime("%Y%m%d_%H%M")
     fn_pos = os.path.join(OUTPUT_DIR, f"portfolio_greeks_{date_tag}.csv")
     fn_tot = os.path.join(OUTPUT_DIR, f"portfolio_greeks_totals_{date_tag}.csv")
 

--- a/tech_signals_ibkr.py
+++ b/tech_signals_ibkr.py
@@ -3,7 +3,7 @@
 tech_signals_ibkr.py — Pull live technical indicators via IBKR / TWS Gateway
 ----------------------------------------------------------------------------
 
-Outputs: tech_signals.csv
+Outputs: tech_signals_YYYYMMDD_HHMM.csv
 Columns:
     timestamp · ticker · ADX · ATR · 20dma · 50dma · 200dma · IV_rank · RSI
     · beta_SPY · ADV30 · next_earnings · OI_near_ATM
@@ -50,12 +50,16 @@ FUTURE_ROOTS = {
 }
 
 # ───────────────────────── CONFIG ──────────────────────────
+# Include time in file names to avoid overwriting when run multiple times a day
 PORTFOLIO_FILES = ["tickers_live.txt", "tickers.txt"]
 DATE_TAG = datetime.utcnow().strftime("%Y%m%d")
+TIME_TAG = datetime.utcnow().strftime("%H%M")
 # save to iCloud Drive Downloads
 OUTPUT_DIR = "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/Downloads"
 os.makedirs(OUTPUT_DIR, exist_ok=True)
-OUTPUT_CSV = os.path.join(OUTPUT_DIR, f"tech_signals_{DATE_TAG}.csv")
+OUTPUT_CSV = os.path.join(
+    OUTPUT_DIR, f"tech_signals_{DATE_TAG}_{TIME_TAG}.csv"
+)
 
 HIST_DAYS       = 300          # enough for SMA200 / ADX
 SPAN_PCT        = 0.05       # ±5 % strike window


### PR DESCRIPTION
## Summary
- add HHMM timestamp components for output CSV filenames
- update README and docstrings accordingly

## Testing
- `pytest -q`