### PR TITLE
Add testing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ If the token is not present, the script will attempt to read `dailyNetLiq.csv` f
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+Run the unit tests with:
+
+```bash
+pytest
 ```
 
 The scripts require Python 3.11+ and the packages listed in `requirements.txt`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest
+pandas
+numpy
+requests
+


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` with pytest and test deps
- document dev installation and pytest usage in README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd0120b70832ead57a5fa13ce3531