### PR TITLE
Add interactive symbol expiry prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ python update_tickers.py
 # Calculate technical indicators using IBKR data
 python tech_signals_ibkr.py
 
+# Interactively choose symbols and expiries
+python option_chain_snapshot.py
+
 # Option-chain snapshot for specific symbols and expiries
 python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
 ```

--- a/tests/test_option_chain_snapshot.py
+++ b/tests/test_option_chain_snapshot.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import unittest
+from unittest.mock import patch
 from datetime import datetime, timedelta
 
 # Provide minimal stubs so import works without optional packages
@@ -49,6 +50,20 @@ class ChooseExpiryTests(unittest.TestCase):
         other = (today + timedelta(days=days+2)).strftime('%Y%m%d')
         result = oc.choose_expiry([other, friday])
         self.assertEqual(result, friday)
+
+
+class PromptSymbolExpiriesTests(unittest.TestCase):
+    def test_prompt_symbol_expiries(self):
+        seq = iter([
+            "AAPL",
+            "20240101,20240108",
+            "TSLA",
+            "",
+            "",
+        ])
+        with patch("builtins.input", lambda _: next(seq)):
+            result = oc.prompt_symbol_expiries()
+        self.assertEqual(result, {"AAPL": ["20240101", "20240108"], "TSLA": []})
 
 
 


### PR DESCRIPTION
## Summary
- add helper prompt_symbol_expiries to build symbol→expiry mapping interactively
- use the new helper in `option_chain_snapshot.py`
- document interactive mode in README
- unit test for prompt_symbol_expiries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e905b2d4832ea0a813735b52d36f