### PR TITLE
Add fuzzy expiry hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ python option_chain_snapshot.py
 python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
 ```
 
+### Expiry hint formats
+
+When prompted for an expiry, you may provide:
+
+* Exact date ``YYYYMMDD``
+* ``YYYYMM`` to select the third Friday of that month (or the first listed expiry)
+* Month name or abbreviation (e.g. ``June`` or ``Jun``)
+* Day and month like ``26 Jun``, ``Jun 26`` or ``26/06``. The script picks the
+  nearest available expiry on or after that date.
+
+Leaving the field blank automatically chooses the next weekly expiry within a
+week or the first Friday that is available.
+
 ## IBKR Setup
 
 Scripts that use `ib_insync` (`historic_prices.py`, `live_feed.py` and

--- a/tests/test_option_chain_snapshot.py
+++ b/tests/test_option_chain_snapshot.py
@@ -66,6 +66,21 @@ class PromptSymbolExpiriesTests(unittest.TestCase):
         self.assertEqual(result, {"AAPL": ["20240101", "20240108"], "TSLA": []})
 
 
+class PickExpiryHintTests(unittest.TestCase):
+    def test_day_month_hint(self):
+        expirations = [
+            "20240621",
+            "20240628",
+            "20240705",
+        ]
+        res1 = oc.pick_expiry_with_hint(expirations, "26 Jun")
+        res2 = oc.pick_expiry_with_hint(expirations, "Jun 26")
+        res3 = oc.pick_expiry_with_hint(expirations, "26/06")
+        self.assertEqual(res1, "20240628")
+        self.assertEqual(res2, "20240628")
+        self.assertEqual(res3, "20240628")
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- support day+month hints in option_chain_snapshot
- explain expiry hint formats in README
- guide users in the prompt about new hint style
- test new fuzzy expiry parsing

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ecb2f448832ebf39b1d904f16282