### PR TITLE
Add AGENTS instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ portfolio_*.csv
 # Ignore Python cache files
 __pycache__/
 *.pyc
+.venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Guidelines for Codex Agents
+
+## Testing
+- Always run `pytest` from the repository root after making changes.
+- Install dev dependencies with `pip install -r requirements-dev.txt` if tests fail due to missing packages.
+
+## Style
+- Format Python code with **black** using the default configuration (line length 88).
+- Keep imports organized and remove unused imports.
+- Use descriptive variable names and add type hints for new functions where practical.
+
+## General
+- Keep commit messages concise, e.g. "Add option chain helper".
+- Avoid network calls in tests; rely on stubs or fixtures.
+- Python version is 3.11+.


### PR DESCRIPTION
## Summary
- add instructions for Codex agents in `AGENTS.md`
- ignore local `.venv` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f819f2dc832ea3caf3e48a6cec30