### PR TITLE
Update README on IBKR OI timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | ------ | ----------- |
 | `historic_prices.py` | Downloads the last 60 days of daily OHLCV data for tickers read from `tickers_live.txt` or `tickers.txt`. If IBKR is reachable, the current account holdings are used as the ticker list. The output is a timestamped CSV in `~/Library/Mobile\ Documents/.../Downloads`. |
 | `live_feed.py` | Takes a snapshot of real‑time quotes for tickers listed in `tickers_live.txt` (falling back to `tickers.txt`). Quotes are pulled from IBKR when available, otherwise from yfinance and FRED. Results are written to `live_quotes_YYYYMMDD_HHMM.csv`. |
-| `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest and near‑ATM implied volatility. |
+| `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest and near‑ATM implied volatility. Falls back to yfinance and Barchart when IBKR OI is unavailable. |
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
 | `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. |
 | `option_chain_snapshot.py` | Saves a complete IBKR option chain to CSV for the entire portfolio or specified symbols, handling live and delayed data automatically. |
@@ -87,6 +87,11 @@ Scripts that use `ib_insync` (`historic_prices.py`, `live_feed.py` and
 running locally with API access enabled (default host `127.0.0.1` and port
 `7497`). Ensure your IBKR configuration allows API connections from your machine
 and that the account is logged in before running these scripts.
+
+IBKR publishes option open-interest once per day after the U.S. close. Real-time
+open interest requires requesting generic tick 101. If IBKR does not report
+current open interest, the scripts automatically fall back to values from
+yfinance or Barchart when available.
 ## Automation
 
 Schedule `update_tickers.py` with cron or another task scheduler to run daily:


### PR DESCRIPTION
## Summary
- document IBKR open interest timing and generic tick requirement
- mention fallback to yfinance/Barchart

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431413bf58832e95a11c741b3de492