### PR TITLE
Add yfinance open interest fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ python option_chain_snapshot.py
 python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
 ```
 
+If open interest is missing from the IBKR feed, the script automatically pulls
+the value from Yahoo Finance.
+
 ### Expiry hint formats
 
 When prompted for an expiry, you may provide:


### PR DESCRIPTION
## Summary
- implement `fetch_yf_open_interest` helper to retrieve open interest via yfinance
- fill NaN open-interest values in `snapshot_chain`
- use the same fallback in `portfolio_greeks.list_positions`
- test the new helper
- document the Yahoo Finance fallback in README

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `black -q option_chain_snapshot.py portfolio_greeks.py tests/test_option_chain_snapshot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431615264c832eb752371dcdb9c4b1