### PR TITLE
Add yfinance open interest fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ python option_chain_snapshot.py
 python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
 ```
 
+If open interest is missing from the IBKR feed, the script automatically pulls
+the value from Yahoo Finance.
+
 ### Expiry hint formats
 
 When prompted for an expiry, you may provide:

--- a/option_chain_snapshot.py
+++ b/option_chain_snapshot.py
@@ -33,6 +33,7 @@ from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
+import yfinance as yf
 from ib_insync import IB, Option, Stock
 from utils.bs import bs_greeks
 
@@ -298,11 +299,11 @@ def _g(tk, field):
     return np.nan
 
 
-
 def _attr(tk, field):
     """Return a numeric ticker attribute or NaN if unavailable."""
     val = getattr(tk, field, np.nan)
     return np.nan if val in (None, -1) else val
+
 
 # ── helper: robust open‑interest getter ──
 def _open_interest_value(tk, right: str):
@@ -321,6 +322,28 @@ def _open_interest_value(tk, right: str):
         if not np.isnan(val):
             return val
     return np.nan
+
+
+def fetch_yf_open_interest(symbol: str, expiry: str) -> dict[tuple[float, str], int]:
+    """Return {(strike, right): open_interest} from Yahoo Finance."""
+    if expiry and len(expiry) == 8 and expiry.isdigit():
+        expiry = f"{expiry[:4]}-{expiry[4:6]}-{expiry[6:]}"
+    try:
+        oc = yf.Ticker(symbol).option_chain(expiry)
+    except Exception as e:  # pragma: no cover - network failures
+        logger.debug("yfinance OI fetch fail %s %s: %s", symbol, expiry, e)
+        return {}
+
+    mapping: dict[tuple[float, str], int] = {}
+    for right, df in ("C", oc.calls), ("P", oc.puts):
+        if getattr(df, "empty", True):
+            continue
+        for _, row in df[["strike", "openInterest"]].dropna().iterrows():
+            try:
+                mapping[(float(row["strike"]), right)] = int(row["openInterest"])
+            except Exception:
+                continue
+    return mapping
 
 
 def _wait_for_snapshots(ib: IB, snaps: list[tuple], timeout=8.0):
@@ -490,7 +513,11 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
 
     # ── one-shot snapshot fallback for missing price / IV / OI ──
     for con, tk in snapshots:
-        oi_names = ("callOpenInterest", "openInterest") if con.right == "C" else ("putOpenInterest", "openInterest")
+        oi_names = (
+            ("callOpenInterest", "openInterest")
+            if con.right == "C"
+            else ("putOpenInterest", "openInterest")
+        )
         price_missing = (tk.bid in (None, -1)) and (tk.last in (None, -1))
         iv_missing = math.isnan(_g(tk, "impliedVolatility"))
         oi_missing = math.isnan(_open_interest_value(tk, con.right))
@@ -581,11 +608,24 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
             }
         )
 
-    return (
+    df = (
         pd.DataFrame(rows).sort_values(["right", "strike"]).reset_index(drop=True)
         if rows
         else pd.DataFrame()
     )
+
+    if not df.empty and df["open_interest"].isna().any():
+        yf_map = fetch_yf_open_interest(symbol, expiry)
+        for (strike, right), oi in yf_map.items():
+            mask = (
+                (df["strike"] == strike)
+                & (df["right"] == right)
+                & df["open_interest"].isna()
+            )
+            if mask.any():
+                df.loc[mask, "open_interest"] = oi
+
+    return df
 
 
 # ─────────────────────────── MAIN ──────────────────────────

--- a/tests/test_option_chain_snapshot.py
+++ b/tests/test_option_chain_snapshot.py
@@ -32,11 +32,12 @@ import importlib
 
 oc = importlib.import_module("option_chain_snapshot")
 
+
 class ChooseExpiryTests(unittest.TestCase):
     def test_weekly_within_seven_days(self):
         today = datetime.utcnow().date()
-        exp_close = (today + timedelta(days=3)).strftime('%Y%m%d')
-        exp_later = (today + timedelta(days=10)).strftime('%Y%m%d')
+        exp_close = (today + timedelta(days=3)).strftime("%Y%m%d")
+        exp_later = (today + timedelta(days=10)).strftime("%Y%m%d")
         result = oc.choose_expiry([exp_close, exp_later])
         self.assertEqual(result, exp_close)
 
@@ -46,21 +47,23 @@ class ChooseExpiryTests(unittest.TestCase):
         days = 8
         while (today + timedelta(days=days)).weekday() != 4:
             days += 1
-        friday = (today + timedelta(days=days)).strftime('%Y%m%d')
-        other = (today + timedelta(days=days+2)).strftime('%Y%m%d')
+        friday = (today + timedelta(days=days)).strftime("%Y%m%d")
+        other = (today + timedelta(days=days + 2)).strftime("%Y%m%d")
         result = oc.choose_expiry([other, friday])
         self.assertEqual(result, friday)
 
 
 class PromptSymbolExpiriesTests(unittest.TestCase):
     def test_prompt_symbol_expiries(self):
-        seq = iter([
-            "AAPL",
-            "20240101,20240108",
-            "TSLA",
-            "",
-            "",
-        ])
+        seq = iter(
+            [
+                "AAPL",
+                "20240101,20240108",
+                "TSLA",
+                "",
+                "",
+            ]
+        )
         with patch("builtins.input", lambda _: next(seq)):
             result = oc.prompt_symbol_expiries()
         self.assertEqual(result, {"AAPL": ["20240101", "20240108"], "TSLA": []})
@@ -81,7 +84,30 @@ class PickExpiryHintTests(unittest.TestCase):
         self.assertEqual(res3, "20240628")
 
 
+class YFinanceFallbackTests(unittest.TestCase):
+    def test_fetch_yf_open_interest(self):
+        import pandas as pd
+
+        class DummyOC:
+            calls = pd.DataFrame({"strike": [100], "openInterest": [10]})
+            puts = pd.DataFrame({"strike": [90], "openInterest": [5]})
+
+        calls = []
+
+        class DummyTicker:
+            def __init__(self, sym):
+                pass
+
+            def option_chain(self, expiry):
+                calls.append(expiry)
+                return DummyOC
+
+        with patch("yfinance.Ticker", DummyTicker):
+            data = oc.fetch_yf_open_interest("AAA", "20240101")
+        self.assertEqual(calls[0], "2024-01-01")
+        self.assertEqual(data[(100.0, "C")], 10)
+        self.assertEqual(data[(90.0, "P")], 5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `fetch_yf_open_interest` helper to retrieve open interest via yfinance
- fill NaN open-interest values in `snapshot_chain`
- use the same fallback in `portfolio_greeks.list_positions`
- test the new helper
- document the Yahoo Finance fallback in README
- fix yfinance expiry format

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `black -q option_chain_snapshot.py tests/test_option_chain_snapshot.py portfolio_greeks.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68431615264c832eb752371dcdb9c4b1