### PR TITLE
Source open interest externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | ------ | ----------- |
 | `historic_prices.py` | Downloads the last 60 days of daily OHLCV data for tickers read from `tickers_live.txt` or `tickers.txt`. If IBKR is reachable, the current account holdings are used as the ticker list. The output is a timestamped CSV in `~/Library/Mobile\ Documents/.../Downloads`. |
 | `live_feed.py` | Takes a snapshot of real‑time quotes for tickers listed in `tickers_live.txt` (falling back to `tickers.txt`). Quotes are pulled from IBKR when available, otherwise from yfinance and FRED. Results are written to `live_quotes_YYYYMMDD_HHMM.csv`. |
-| `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest and near‑ATM implied volatility. |
+| `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest (fetched from Yahoo Finance) and near‑ATM implied volatility. |
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
 | `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. |
 | `option_chain_snapshot.py` | Saves a complete IBKR option chain to CSV for the entire portfolio or specified symbols, handling live and delayed data automatically. |
@@ -67,8 +67,7 @@ python option_chain_snapshot.py
 python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
 ```
 
-If open interest is missing from the IBKR feed, the script automatically pulls
-the value from Yahoo Finance.
+Open interest values are sourced from Yahoo Finance rather than the IBKR feed.
 
 ### Expiry hint formats
 

--- a/option_chain_snapshot.py
+++ b/option_chain_snapshot.py
@@ -306,22 +306,6 @@ def _attr(tk, field):
 
 
 # ── helper: robust open‑interest getter ──
-def _open_interest_value(tk, right: str):
-    """
-    Return the first non‑NaN open‑interest value available for this option.
-    For calls we prefer `callOpenInterest`, for puts `putOpenInterest`,
-    but we gracefully fall back to the generic `openInterest` field if
-    the side‑specific attribute isn’t populated (older API / data source).
-    """
-    if right == "C":
-        names = ("callOpenInterest", "openInterest")
-    else:
-        names = ("putOpenInterest", "openInterest")
-    for nm in names:
-        val = _attr(tk, nm)
-        if not np.isnan(val):
-            return val
-    return np.nan
 
 
 def fetch_yf_open_interest(symbol: str, expiry: str) -> dict[tuple[float, str], int]:
@@ -391,6 +375,9 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
         len(chain.expirations),
     )
     expiry = pick_expiry_with_hint(sorted(chain.expirations), expiry_hint)
+
+    # always fetch open interest from Yahoo Finance
+    yf_open_interest = fetch_yf_open_interest(symbol, expiry)
 
     # trading class
     root_tc = (
@@ -509,17 +496,11 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
     for _, snap in snapshots:
         ib.cancelMktData(snap.contract)
 
-    # ── one-shot snapshot fallback for missing price / IV / OI ──
+    # ── one-shot snapshot fallback for missing price/IV ──
     for con, tk in snapshots:
-        oi_names = (
-            ("callOpenInterest", "openInterest")
-            if con.right == "C"
-            else ("putOpenInterest", "openInterest")
-        )
         price_missing = (tk.bid in (None, -1)) and (tk.last in (None, -1))
         iv_missing = math.isnan(_g(tk, "impliedVolatility"))
-        oi_missing = math.isnan(_open_interest_value(tk, con.right))
-        if price_missing or iv_missing or oi_missing:
+        if price_missing or iv_missing:
             snap = ib.reqMktData(
                 con, "", True, False
             )  # snapshot: genericTickList must be empty
@@ -530,27 +511,9 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
                     setattr(tk, fld, val)
             if getattr(snap, "modelGreeks", None):
                 tk.modelGreeks = snap.modelGreeks
-            # Copy open‑interest (try both side‑specific and generic)
-            for nm in oi_names:
-                if getattr(snap, nm, None) not in (None, -1):
-                    setattr(tk, nm, getattr(snap, nm))
             # Copy volume if present
             if getattr(snap, "volume", None) not in (None, -1):
                 tk.volume = snap.volume
-            # second pass just for open‑interest if it's still missing
-            if math.isnan(_open_interest_value(tk, con.right)):
-                # stream OI via generic tick 101
-                snap_oi = ib.reqMktData(
-                    con,
-                    "101",
-                    snapshot=False,
-                    regulatorySnapshot=False,
-                )
-                _wait_attr(snap_oi, oi_names[0])
-                if getattr(snap_oi, oi_names[0], None) not in (None, -1):
-                    setattr(tk, oi_names[0], getattr(snap_oi, oi_names[0]))
-                if snap_oi.contract:
-                    ib.cancelMktData(snap_oi.contract)
             if snap.contract:
                 ib.cancelMktData(snap.contract)
 
@@ -601,7 +564,7 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
                 "gamma": gamma_val,
                 "vega": vega_val,
                 "theta": theta_val,
-                "open_interest": _open_interest_value(tk, con.right),
+                "open_interest": yf_open_interest.get((con.strike, con.right), np.nan),
                 "volume": _attr(tk, "volume"),
             }
         )
@@ -611,17 +574,6 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
         if rows
         else pd.DataFrame()
     )
-
-    if not df.empty and df["open_interest"].isna().any():
-        yf_map = fetch_yf_open_interest(symbol, expiry)
-        for (strike, right), oi in yf_map.items():
-            mask = (
-                (df["strike"] == strike)
-                & (df["right"] == right)
-                & df["open_interest"].isna()
-            )
-            if mask.any():
-                df.loc[mask, "open_interest"] = oi
 
     return df
 

--- a/trades_report.py
+++ b/trades_report.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 import argparse
 import calendar
 import csv
+import re
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 
 from typing import Iterable, List, Tuple
 
 import pandas as pd
-
 
 
 @dataclass
@@ -26,7 +26,6 @@ class Trade:
 
 MONTH_MAP = {m.lower(): i for i, m in enumerate(calendar.month_name) if m}
 MONTH_MAP.update({m.lower(): i for i, m in enumerate(calendar.month_abbr) if m})
-
 
 
 def date_range_from_phrase(phrase: str, ref: date | None = None) -> Tuple[date, date]:
@@ -90,6 +89,5 @@ def main() -> None:
     else:
         p.print_help()
         return
-
 
     main()


### PR DESCRIPTION
## Summary
- outsource open interest data from Yahoo Finance
- rely on external open interest in portfolio greeks
- import `re` in trades report helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431d31db40832e996952a558105767