### PR TITLE
Update README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. |
 | `option_chain_snapshot.py` | Saves a complete IBKR option chain to CSV for the entire portfolio or specified symbols, handling live and delayed data automatically. |
 | `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. |
+| `trades_report.py` | Exports executions and open orders from IBKR to CSV for a chosen date range. |
 
 ### CP_REFRESH_TOKEN
 `net_liq_history_export.py` looks for the environment variable `CP_REFRESH_TOKEN` when pulling data from the Client Portal API. Set it before running the script:
@@ -44,7 +45,7 @@ pytest
 ```
 
 The scripts require Python 3.11+ and the packages listed in `requirements.txt`.
-`pandas_datareader` is needed for downloading FRED data in `live_feed.py`, and `requests` is required by `net_liq_history_export.py` for accessing the IBKR Client Portal API.
+`pandas_datareader` is needed for downloading FRED data in `live_feed.py`, and `requests` is required by `net_liq_history_export.py` for accessing the IBKR Client Portal API. `matplotlib` is optional and only needed when using the `--plot` flag with `net_liq_history_export.py`.
 
 ## Usage Examples
 
@@ -65,6 +66,8 @@ python option_chain_snapshot.py
 
 # Option-chain snapshot for specific symbols and expiries
 python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
+# Export today's executions and open orders
+python trades_report.py --today
 ```
 
 Open interest values are sourced from Yahoo Finance rather than the IBKR feed.

--- a/tests/test_trades_report.py
+++ b/tests/test_trades_report.py
@@ -63,11 +63,32 @@ class FilterTradesTests(unittest.TestCase):
         ]
         self.trades = [
             tr.Trade(
-                pd.to_datetime(r["date"]).date(),
-                r["ticker"],
-                r["side"],
-                r["qty"],
-                r["price"],
+                exec_id="0",
+                perm_id=0,
+                order_id=0,
+                symbol=r["ticker"],
+                sec_type="STK",
+                currency="USD",
+                expiry=None,
+                strike=None,
+                right=None,
+                multiplier=None,
+                exchange="",
+                primary_exchange=None,
+                trading_class=None,
+                datetime=pd.to_datetime(r["date"]),
+                side=r["side"],
+                qty=r["qty"],
+                price=r["price"],
+                avg_price=r["price"],
+                cum_qty=r["qty"],
+                last_liquidity="",
+                commission=None,
+                commission_currency=None,
+                realized_pnl=None,
+                account=None,
+                model_code=None,
+                order_ref=None,
             )
             for r in data
         ]
@@ -76,9 +97,8 @@ class FilterTradesTests(unittest.TestCase):
         start, end = date(2024, 6, 1), date(2024, 6, 30)
         res = tr.filter_trades(self.trades, start, end)
         self.assertEqual(len(res), 2)
-        self.assertEqual(res[0].ticker, "A")
-        self.assertEqual(res[1].ticker, "B")
-
+        self.assertEqual(res[0].symbol, "A")
+        self.assertEqual(res[1].symbol, "B")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document `trades_report.py` and optional matplotlib dependency
- add example usage for trade reports
- update trades_report test for current `Trade` dataclass

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684326c006c4832e8dd6ec7341dca358