### PR TITLE
Add Makefile and clarify setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+VENV=.venv
+PIP=$(VENV)/bin/pip
+PYTEST=$(VENV)/bin/pytest
+
+.PHONY: setup test
+
+setup:
+	python -m venv $(VENV)
+	$(PIP) install -r requirements.txt
+	$(PIP) install -r requirements-dev.txt
+
+test:
+	$(PYTEST)

--- a/README.md
+++ b/README.md
@@ -36,13 +36,11 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
-```
-
-Run the unit tests with:
-
-```bash
 pytest
 ```
+
+The included *Makefile* provides `make setup` and `make test` targets to automate
+these steps if desired.
 
 The scripts require Python 3.11+ and the packages listed in `requirements.txt`.
 `pandas_datareader` is needed for downloading FRED data in `live_feed.py`, and `requests` is required by `net_liq_history_export.py` for accessing the IBKR Client Portal API. `matplotlib` is optional and only needed when using the `--plot` flag with `net_liq_history_export.py`.


### PR DESCRIPTION
## Summary
- document dependency installation and tests as a single block
- mention optional Makefile automation
- provide Makefile with setup and test targets

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481a4eb004832e90743baae07500f9