### PR TITLE
Add output format selection with PDF

### DIFF
--- a/daily_pulse.py
+++ b/daily_pulse.py
@@ -1,4 +1,53 @@
 import pandas as pd
+import numpy as np
+
+
+def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Return DataFrame with technical indicators."""
+    df = df.sort_values("date").copy()
+    grp = df.groupby("ticker")
+    df["pct_change"] = grp["close"].pct_change(fill_method=None)
+    df["sma20"] = grp["close"].transform(lambda s: s.rolling(20, min_periods=1).mean())
+    df["ema20"] = grp["close"].transform(lambda s: s.ewm(span=20, min_periods=1).mean())
+    high_low = df["high"] - df["low"]
+    prev_close = grp["close"].shift(1)
+    tr = pd.concat(
+        [
+            high_low,
+            (df["high"] - prev_close).abs(),
+            (df["low"] - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    df["tr"] = tr
+    df["atr14"] = grp["tr"].transform(lambda s: s.rolling(14, min_periods=1).mean())
+    df.drop(columns="tr", inplace=True)
+    delta = grp["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(14, min_periods=1).mean()
+    avg_loss = loss.rolling(14, min_periods=1).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    df["rsi14"] = 100 - (100 / (1 + rs))
+    ema12 = grp["close"].transform(lambda s: s.ewm(span=12, min_periods=1).mean())
+    ema26 = grp["close"].transform(lambda s: s.ewm(span=26, min_periods=1).mean())
+    df["macd"] = ema12 - ema26
+    df["macd_signal"] = grp["macd"].transform(
+        lambda s: s.ewm(span=9, min_periods=1).mean()
+    )
+    rolling_mean = grp["close"].transform(lambda s: s.rolling(20, min_periods=1).mean())
+    rolling_std = grp["close"].transform(lambda s: s.rolling(20, min_periods=1).std())
+    df["bb_upper"] = rolling_mean + 2 * rolling_std
+    df["bb_lower"] = rolling_mean - 2 * rolling_std
+    df["vwap"] = grp.apply(
+        lambda g: (g["close"] * g["volume"]).cumsum() / g["volume"].cumsum()
+    ).reset_index(level=0, drop=True)
+    df["real_vol_30"] = grp["pct_change"].transform(
+        lambda s: s.rolling(30, min_periods=1).std() * np.sqrt(252)
+    )
+    return df
+
+
 def generate_report(df: pd.DataFrame, output_path: str) -> None:
     """
     Write latest metrics for each ticker to ``output_path`` as CSV.

--- a/historic_prices.py
+++ b/historic_prices.py
@@ -1,9 +1,23 @@
 import os
 import pandas as pd
 import yfinance as yf
+
+try:  # optional dependencies
+    import xlsxwriter  # type: ignore
+except Exception:  # pragma: no cover - optional
+    xlsxwriter = None  # type: ignore
+
+try:
+    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib import colors
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+except Exception:  # pragma: no cover - optional
+    SimpleDocTemplate = Table = TableStyle = colors = letter = landscape = None
+
 # optional progress bar
 try:
     from tqdm import tqdm
+
     PROGRESS = True
 except ImportError:
     PROGRESS = False
@@ -12,14 +26,16 @@ from datetime import datetime
 # ---------- IBKR optional integration ----------
 try:
     from ib_insync import IB, Stock
+
     IB_AVAILABLE = True
 except ImportError:
     IB_AVAILABLE = False
 
-IB_HOST, IB_PORT, IB_CID = "127.0.0.1", 7497, 3   # separate clientId for historic pull
+IB_HOST, IB_PORT, IB_CID = "127.0.0.1", 7497, 3  # separate clientId for historic pull
 
 EXTRA_TICKERS = ["SPY", "QQQ", "IWM", "^VIX", "DX-Y.NYB"]  # core indices
 PROXY_MAP = {"VIX": "^VIX", "VVIX": "^VVIX", "DXY": "DX-Y.NYB"}
+
 
 def _tickers_from_ib() -> list[str]:
     """Return unique stock tickers from current IBKR account positions."""
@@ -35,21 +51,24 @@ def _tickers_from_ib() -> list[str]:
     if not positions:
         return []
     # extract underlying symbol for stocks only
-    tickers = {p.contract.symbol.upper()
-               for p in positions if p.contract.secType == "STK"}
+    tickers = {
+        p.contract.symbol.upper() for p in positions if p.contract.secType == "STK"
+    }
     return sorted(tickers)
 
-PORTFOLIO_FILES = ["tickers_live.txt", "tickers.txt"]      # first existing file wins
+
+PORTFOLIO_FILES = ["tickers_live.txt", "tickers.txt"]  # first existing file wins
 
 # Timestamped output (UTC). Includes time so repeated runs don't overwrite.
 DATE_TAG = datetime.utcnow().strftime("%Y%m%d")
 TIME_TAG = datetime.utcnow().strftime("%H%M")
 # Save to iCloud Drive ▸ Downloads
-OUTPUT_DIR = "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/Downloads"
-os.makedirs(OUTPUT_DIR, exist_ok=True)
-OUTPUT_CSV = os.path.join(
-    OUTPUT_DIR, f"historic_prices_{DATE_TAG}_{TIME_TAG}.csv"
+OUTPUT_DIR = (
+    "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/Downloads"
 )
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+OUTPUT_CSV = os.path.join(OUTPUT_DIR, f"historic_prices_{DATE_TAG}_{TIME_TAG}.csv")
+
 
 def load_tickers() -> list[str]:
     """Return unique tickers prioritising IBKR holdings; otherwise text file."""
@@ -68,6 +87,7 @@ def load_tickers() -> list[str]:
     mapped = [PROXY_MAP.get(t, t) for t in user_tickers]
     return sorted(set(mapped + EXTRA_TICKERS))
 
+
 def fetch_and_prepare_data(tickers):
     """
     Batch-fetch OHLCV data for tickers over last 60 days with daily interval.
@@ -77,9 +97,14 @@ def fetch_and_prepare_data(tickers):
     """
     if not tickers:
         raise ValueError("No data fetched for any ticker.")
-    data = yf.download(tickers=tickers, period="60d", interval="1d",
-                       group_by='ticker', auto_adjust=False)
-    columns = ["date","ticker","open","high","low","close","adj_close","volume"]
+    data = yf.download(
+        tickers=tickers,
+        period="60d",
+        interval="1d",
+        group_by="ticker",
+        auto_adjust=False,
+    )
+    columns = ["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
     if data.empty:
         return pd.DataFrame(columns=columns)
     dfs = []
@@ -96,28 +121,101 @@ def fetch_and_prepare_data(tickers):
         dfs.append(df_t)
     result = pd.concat(dfs, ignore_index=True)
     # Rename columns and enforce types
-    result = result.rename(columns={
-        "Date": "date",
-        "Ticker": "ticker",
-        "Open": "open",
-        "High": "high",
-        "Low": "low",
-        "Close": "close",
-        "Adj Close": "adj_close",
-        "Volume": "volume"
-    })
+    result = result.rename(
+        columns={
+            "Date": "date",
+            "Ticker": "ticker",
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Adj Close": "adj_close",
+            "Volume": "volume",
+        }
+    )
     result["date"] = result["date"].dt.strftime("%Y-%m-%d")
     result["volume"] = result["volume"].fillna(0).astype(int)
     return result[columns]
+
 
 def save_to_csv(df: pd.DataFrame):
     df.to_csv(OUTPUT_CSV, index=False)
     print(f"✅  Saved {len(df):,} rows → {OUTPUT_CSV}")
 
-def main():
+
+def save_to_excel(df: pd.DataFrame, path: str) -> None:
+    with pd.ExcelWriter(
+        path, engine="xlsxwriter", datetime_format="yyyy-mm-dd"
+    ) as writer:
+        df.to_excel(writer, sheet_name="Prices", index=False)
+
+
+def save_to_pdf(df: pd.DataFrame, path: str) -> None:
+    rows_data = [df.columns.tolist()] + df.values.tolist()
+    doc = SimpleDocTemplate(
+        path,
+        pagesize=landscape(letter),
+        rightMargin=18,
+        leftMargin=18,
+        topMargin=18,
+        bottomMargin=18,
+    )
+    table = Table(rows_data, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 6),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+            ]
+        )
+    )
+    doc.build([table])
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Download recent historical prices")
+    out_grp = p.add_mutually_exclusive_group()
+    out_grp.add_argument(
+        "--excel",
+        action="store_true",
+        help="Save output as Excel instead of CSV.",
+    )
+    out_grp.add_argument(
+        "--pdf",
+        action="store_true",
+        help="Save output as PDF instead of CSV.",
+    )
+    args = p.parse_args()
+
+    if not args.excel and not args.pdf:
+        try:
+            choice = (
+                input("Select output format [csv / excel / pdf] (default csv): ")
+                .strip()
+                .lower()
+            )
+        except EOFError:
+            choice = ""
+        if choice in {"excel", "xlsx"}:
+            args.excel = True
+        elif choice == "pdf":
+            args.pdf = True
+
     tickers = load_tickers()
     df = fetch_and_prepare_data(tickers)
-    save_to_csv(df)
+    if args.excel:
+        path = OUTPUT_CSV.replace(".csv", ".xlsx")
+        save_to_excel(df, path)
+    elif args.pdf:
+        path = OUTPUT_CSV.replace(".csv", ".pdf")
+        save_to_pdf(df, path)
+    else:
+        save_to_csv(df)
+
 
 if __name__ == "__main__":
     main()

--- a/trades_report.py
+++ b/trades_report.py
@@ -15,7 +15,18 @@ from typing import Iterable, List, Tuple
 from typing import Optional
 
 import pandas as pd
-import xlsxwriter
+
+try:  # optional dependencies
+    import xlsxwriter  # type: ignore
+except Exception:  # pragma: no cover - optional
+    xlsxwriter = None  # type: ignore
+
+try:
+    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib import colors
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+except Exception:  # pragma: no cover - optional
+    SimpleDocTemplate = Table = TableStyle = colors = letter = landscape = None
 import calendar
 
 try:  # optional dependency
@@ -141,6 +152,7 @@ def date_range_from_phrase(phrase: str, ref: date | None = None) -> Tuple[date, 
         return d, d
     raise ValueError(f"Unrecognised date phrase: {phrase}")
 
+
 # ─────────────────── interactive date‑range prompt ───────────────────
 def prompt_date_range() -> Tuple[date, date]:
     """
@@ -195,11 +207,11 @@ def fetch_trades_ib(start: date, end: date) -> Tuple[List[Trade], List[OpenOrder
         return [], []
 
     # --- Capture executions & commission reports ------------------------------
-    comm_map: dict[str, 'CommissionReport'] = {}
+    comm_map: dict[str, "CommissionReport"] = {}
 
     # CommissionReport only comes via callback; cache them by execId
     def _comm(*args):
-        report = args[-1]          # CommissionReport is always last arg
+        report = args[-1]  # CommissionReport is always last arg
         comm_map[report.execId] = report
 
     ib.commissionReportEvent += _comm
@@ -220,7 +232,7 @@ def fetch_trades_ib(start: date, end: date) -> Tuple[List[Trade], List[OpenOrder
 
         # ensure contract is qualified for full fields
         if not contract.conId:
-            qualified, = ib.qualifyContracts(contract)
+            (qualified,) = ib.qualifyContracts(contract)
             contract = qualified
 
         comm = comm_map.get(ex.execId, None)
@@ -235,7 +247,11 @@ def fetch_trades_ib(start: date, end: date) -> Tuple[List[Trade], List[OpenOrder
                 expiry=getattr(contract, "lastTradeDateOrContractMonth", None),
                 strike=getattr(contract, "strike", None),
                 right=getattr(contract, "right", None),
-                multiplier=int(contract.multiplier) if getattr(contract, "multiplier", None) else None,
+                multiplier=(
+                    int(contract.multiplier)
+                    if getattr(contract, "multiplier", None)
+                    else None
+                ),
                 exchange=ex.exchange,
                 primary_exchange=getattr(contract, "primaryExchange", None),
                 trading_class=getattr(contract, "tradingClass", None),
@@ -258,7 +274,7 @@ def fetch_trades_ib(start: date, end: date) -> Tuple[List[Trade], List[OpenOrder
     # --- Capture open orders ---------------------------------------------------
     ib.reqAllOpenOrders()
     ib.sleep(0.6)  # allow gateway to populate the cache
-    open_trades_snapshot: List['Trade'] = ib.openTrades()
+    open_trades_snapshot: List["Trade"] = ib.openTrades()
 
     open_orders: List[OpenOrder] = []
     for tr in open_trades_snapshot:
@@ -323,7 +339,9 @@ def save_csvs(
 
 
 # Helper for Excel export: auto-fit columns
-def _auto_fit_columns(df: pd.DataFrame, writer: pd.ExcelWriter, sheet_name: str) -> None:
+def _auto_fit_columns(
+    df: pd.DataFrame, writer: pd.ExcelWriter, sheet_name: str
+) -> None:
     """
     Auto‑adjust column widths based on the longest value in each column.
     """
@@ -410,7 +428,9 @@ def save_excel(
     ]
     df_open = df_open[[c for c in open_cols_preferred if c in df_open.columns]]
 
-    with pd.ExcelWriter(excel_path, engine="xlsxwriter", datetime_format="yyyy-mm-dd hh:mm:ss") as writer:
+    with pd.ExcelWriter(
+        excel_path, engine="xlsxwriter", datetime_format="yyyy-mm-dd hh:mm:ss"
+    ) as writer:
         if not df_trades.empty:
             df_trades.to_excel(writer, sheet_name="Trades", index=False)
             _auto_fit_columns(df_trades, writer, "Trades")
@@ -436,6 +456,71 @@ def save_excel(
     return excel_path
 
 
+def save_pdf(
+    trades: Iterable[Trade], open_orders: Iterable[OpenOrder], start: date, end: date
+) -> Optional[Path]:
+    trades = list(trades)
+    open_orders = list(open_orders)
+    if not trades and not open_orders:
+        return None
+
+    ts = TIME_TAG
+    base = f"{start.strftime('%Y%m%d')}-{end.strftime('%Y%m%d')}_{ts}"
+    pdf_path = OUTPUT_DIR / f"trades_report_{base}.pdf"
+
+    df_trades = pd.DataFrame([t.__dict__ for t in trades])
+    df_open = pd.DataFrame([o.__dict__ for o in open_orders])
+
+    elements = []
+    doc = SimpleDocTemplate(
+        str(pdf_path),
+        pagesize=landscape(letter),
+        rightMargin=18,
+        leftMargin=18,
+        topMargin=18,
+        bottomMargin=18,
+    )
+    if not df_trades.empty:
+        tbl_trades = Table(
+            [df_trades.columns.tolist()] + df_trades.values.tolist(), repeatRows=1
+        )
+        tbl_trades.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 6),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+                ]
+            )
+        )
+        elements.append(tbl_trades)
+
+    if not df_open.empty:
+        elements.append(Table([[" "]]))
+        tbl_open = Table(
+            [df_open.columns.tolist()] + df_open.values.tolist(), repeatRows=1
+        )
+        tbl_open.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 6),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+                ]
+            )
+        )
+        elements.append(tbl_open)
+
+    doc.build(elements)
+    return pdf_path
+
+
 def main() -> None:
     p = argparse.ArgumentParser(description="Filter trade history")
     g = p.add_mutually_exclusive_group()
@@ -447,13 +532,33 @@ def main() -> None:
     p.add_argument("--end")
     p.add_argument("--ibport", type=int, help="Override API port (default 7497)")
     p.add_argument("--cid", type=int, help="Override IB clientId (default 5)")
-    p.add_argument(
-        "--no-csv",
+    out_grp = p.add_mutually_exclusive_group()
+    out_grp.add_argument(
+        "--excel",
         action="store_true",
-        help="Skip generating CSV files and only produce the Excel report",
+        help="Save output as an Excel workbook instead of CSV.",
+    )
+    out_grp.add_argument(
+        "--pdf",
+        action="store_true",
+        help="Save output as a PDF report instead of CSV.",
     )
 
     args = p.parse_args()
+
+    if not args.excel and not args.pdf:
+        try:
+            choice = (
+                input("Select output format [csv / excel / pdf] (default csv): ")
+                .strip()
+                .lower()
+            )
+        except EOFError:
+            choice = ""
+        if choice in {"excel", "xlsx"}:
+            args.excel = True
+        elif choice == "pdf":
+            args.pdf = True
 
     global IB_PORT, IB_CID
     if args.ibport:
@@ -484,16 +589,18 @@ def main() -> None:
 
     trades = filter_trades(trades, start, end)
 
-    if args.no_csv:
-        print("ℹ️  CSV generation skipped (--no-csv).")
+    if args.excel:
+        excel_path = save_excel(trades, open_orders, start, end)
+        if excel_path:
+            print(f"\u2705  Saved Excel report to {excel_path}")
+    elif args.pdf:
+        pdf_path = save_pdf(trades, open_orders, start, end)
+        if pdf_path:
+            print(f"\u2705  Saved PDF report to {pdf_path}")
     else:
         trade_path, oo_path = save_csvs(trades, open_orders, start, end)
         print(f"\u2705  Saved {len(trades)} trades to {trade_path}")
         print(f"\u2705  Saved {len(open_orders)} open orders to {oo_path}")
-
-    excel_path = save_excel(trades, open_orders, start, end)
-    if excel_path:
-        print(f"\u2705  Saved Excel report to {excel_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support csv/excel/pdf output selection across exporter scripts
- ask the user for desired output type when no flag provided
- make optional dependencies optional
- implement missing technical indicator helper

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491f8ce96c832e9f063eaa332e9842