### PR TITLE
Update docs for Excel/PDF outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 
 | Script | Description |
 | ------ | ----------- |
-| `historic_prices.py` | Downloads the last 60 days of daily OHLCV data for tickers read from `tickers_live.txt` or `tickers.txt`. If IBKR is reachable, the current account holdings are used as the ticker list. The output is a timestamped CSV in `~/Library/Mobile\ Documents/.../Downloads`. |
+| `historic_prices.py` | Downloads the last 60 days of daily OHLCV data for tickers read from `tickers_live.txt` or `tickers.txt`. If IBKR is reachable, the current account holdings are used as the ticker list. The output is a timestamped CSV in `~/Library/Mobile\ Documents/.../Downloads`. Use `--excel` or `--pdf` to save as those formats instead. |
 | `live_feed.py` | Takes a snapshot of real‑time quotes for tickers listed in `tickers_live.txt` (falling back to `tickers.txt`). Quotes are pulled from IBKR when available, otherwise from yfinance and FRED. Results are written to `live_quotes_YYYYMMDD_HHMM.csv`. |
 | `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest (fetched from Yahoo Finance) and near‑ATM implied volatility. |
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
-| `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. |
-| `option_chain_snapshot.py` | Saves a complete IBKR option chain to CSV for the entire portfolio or specified symbols, handling live and delayed data automatically. |
-| `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. |
-| `trades_report.py` | Exports executions and open orders from IBKR to CSV for a chosen date range. |
+| `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. Pass `--excel` or `--pdf` for alternative formats. |
+| `option_chain_snapshot.py` | Saves a complete IBKR option chain for the portfolio or given symbols. Defaults to CSV; use `--excel` or `--pdf` to change the output type. |
+| `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. Supports `--excel` and `--pdf` outputs. |
+| `trades_report.py` | Exports executions and open orders from IBKR to CSV for a chosen date range. Add `--excel` or `--pdf` for formatted reports. |
 
 ### CP_REFRESH_TOKEN
 `net_liq_history_export.py` looks for the environment variable `CP_REFRESH_TOKEN` when pulling data from the Client Portal API. Set it before running the script:
@@ -43,7 +43,7 @@ The included *Makefile* provides `make setup` and `make test` targets to automat
 these steps if desired.
 
 The scripts require Python 3.11+ and the packages listed in `requirements.txt`.
-`pandas_datareader` is needed for downloading FRED data in `live_feed.py`, and `requests` is required by `net_liq_history_export.py` for accessing the IBKR Client Portal API. `matplotlib` is optional and only needed when using the `--plot` flag with `net_liq_history_export.py`.
+`pandas_datareader` is needed for downloading FRED data in `live_feed.py`, and `requests` is required by `net_liq_history_export.py` for accessing the IBKR Client Portal API. `xlsxwriter` enables Excel exports and `reportlab` enables PDF output. `matplotlib` is optional and only needed when using the `--plot` flag with `net_liq_history_export.py`.
 
 ## Usage Examples
 

--- a/docs/PDR.md
+++ b/docs/PDR.md
@@ -6,7 +6,7 @@ This document outlines the goals of the project and provides a high level overvi
 
 * Keep a lightweight toolkit to pull snapshots of historical prices, live quotes and portfolio Greeks.
 * Prefer IBKR market data when available but gracefully fall back to yfinance and FRED for public data.
-* Store results as timestamped CSV files under the Downloads directory so they can be easily analysed elsewhere.
+* Store results as timestamped CSV files under the Downloads directory so they can be easily analysed elsewhere. Most scripts also support Excel (`--excel`) and PDF (`--pdf`) output.
 
 ## Script Interaction
 


### PR DESCRIPTION
## Summary
- document `--excel` and `--pdf` options in README
- clarify optional packages for Excel/PDF support
- note additional output formats in design rationale

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492454fd94832e9f7654c528935db0