### PR TITLE
Add CLI to daily_pulse and new test

### DIFF
--- a/daily_pulse.py
+++ b/daily_pulse.py
@@ -1,5 +1,17 @@
+import os
+import argparse
+from datetime import datetime
+
 import pandas as pd
 import numpy as np
+
+DATE_TAG = datetime.utcnow().strftime("%Y%m%d")
+TIME_TAG = datetime.utcnow().strftime("%H%M")
+OUTPUT_DIR = (
+    "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/Downloads"
+)
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+DEFAULT_OUTPUT = os.path.join(OUTPUT_DIR, f"daily_pulse_{DATE_TAG}_{TIME_TAG}.csv")
 
 
 def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
@@ -82,3 +94,31 @@ def generate_report(df: pd.DataFrame, output_path: str) -> None:
 
     latest = latest[cols].round(4)
     latest.to_csv(output_path)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Generate daily technical summary from OHLC data"
+    )
+    p.add_argument(
+        "csv",
+        nargs="?",
+        default="historic_prices_sample.csv",
+        help="Input OHLCV CSV file",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default=DEFAULT_OUTPUT,
+        help="Path to save the summary CSV",
+    )
+    args = p.parse_args()
+
+    df = pd.read_csv(args.csv, parse_dates=["date"])
+    df = compute_indicators(df)
+    generate_report(df, args.output)
+    print(f"✅  Saved report → {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_daily_pulse.py
+++ b/tests/test_daily_pulse.py
@@ -1,6 +1,8 @@
 import unittest
 import pandas as pd
 import numpy as np
+import tempfile
+from pathlib import Path
 
 import daily_pulse as dp
 
@@ -42,6 +44,15 @@ class DailyPulseTests(unittest.TestCase):
         df.loc[0, "close"] = np.nan
         result = dp.compute_indicators(df)
         self.assertEqual(len(result), len(df))
+
+    def test_generate_report_file(self):
+        df_ind = dp.compute_indicators(self.df)
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "pulse.csv"
+            dp.generate_report(df_ind, str(out))
+            self.assertTrue(out.exists())
+            saved = pd.read_csv(out, index_col=0)
+            self.assertIn("close", saved.columns)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add command line interface to daily_pulse
- write report to default Downloads folder
- test that generate_report creates the file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684924eb07c0832ea6d530324a5385b5