### PR TITLE
Add PDF/Excel output for daily_pulse and fix vwap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | `live_feed.py` | Takes a snapshot of real‑time quotes for tickers listed in `tickers_live.txt` (falling back to `tickers.txt`). Quotes are pulled from IBKR when available, otherwise from yfinance and FRED. Results are written to `live_quotes_YYYYMMDD_HHMM.csv`. |
 | `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest (fetched from Yahoo Finance) and near‑ATM implied volatility. |
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
+| `daily_pulse.py` | Generates a one-row-per-ticker summary of technical indicators from an OHLCV CSV. Defaults to CSV output; use `--excel` or `--pdf` for other formats. |
 | `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. Pass `--excel` or `--pdf` for alternative formats. |
 | `option_chain_snapshot.py` | Saves a complete IBKR option chain for the portfolio or given symbols. Defaults to CSV; use `--excel` or `--pdf` to change the output type. |
 | `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. Supports `--excel` and `--pdf` outputs. |

--- a/daily_pulse.py
+++ b/daily_pulse.py
@@ -5,6 +5,18 @@ from datetime import datetime
 import pandas as pd
 import numpy as np
 
+try:  # optional dependencies
+    import xlsxwriter  # type: ignore
+except Exception:  # pragma: no cover - optional
+    xlsxwriter = None  # type: ignore
+
+try:  # optional dependencies
+    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib import colors
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+except Exception:  # pragma: no cover - optional
+    SimpleDocTemplate = Table = TableStyle = colors = letter = landscape = None
+
 DATE_TAG = datetime.utcnow().strftime("%Y%m%d")
 TIME_TAG = datetime.utcnow().strftime("%H%M")
 OUTPUT_DIR = (
@@ -51,22 +63,17 @@ def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
     rolling_std = grp["close"].transform(lambda s: s.rolling(20, min_periods=1).std())
     df["bb_upper"] = rolling_mean + 2 * rolling_std
     df["bb_lower"] = rolling_mean - 2 * rolling_std
-    df["vwap"] = grp.apply(
-        lambda g: (g["close"] * g["volume"]).cumsum() / g["volume"].cumsum()
-    ).reset_index(level=0, drop=True)
+    df["vwap"] = (df["close"] * df["volume"]).groupby(df["ticker"]).cumsum() / df[
+        "volume"
+    ].groupby(df["ticker"]).cumsum()
     df["real_vol_30"] = grp["pct_change"].transform(
         lambda s: s.rolling(30, min_periods=1).std() * np.sqrt(252)
     )
     return df
 
 
-def generate_report(df: pd.DataFrame, output_path: str) -> None:
-    """
-    Write latest metrics for each ticker to ``output_path`` as CSV.
-
-    The report now includes all key technical fields so downstream
-    scanners don't miss any derived signals.
-    """
+def generate_report(df: pd.DataFrame, output_path: str, fmt: str = "csv") -> None:
+    """Write the latest metrics for each ticker to ``output_path``."""
     latest = (
         df.sort_values("date")
         .groupby("ticker", as_index=False)
@@ -93,7 +100,42 @@ def generate_report(df: pd.DataFrame, output_path: str) -> None:
     cols = [c for c in cols if c in latest.columns]
 
     latest = latest[cols].round(4)
-    latest.to_csv(output_path)
+
+    if fmt == "excel":
+        with pd.ExcelWriter(
+            output_path, engine="xlsxwriter", datetime_format="yyyy-mm-dd"
+        ) as writer:
+            latest.reset_index().to_excel(writer, sheet_name="Pulse", index=False)
+    elif fmt == "pdf":
+        if SimpleDocTemplate is None:
+            raise RuntimeError("reportlab is required for PDF output")
+        rows = [
+            latest.reset_index().columns.tolist()
+        ] + latest.reset_index().values.tolist()
+        doc = SimpleDocTemplate(
+            output_path,
+            pagesize=landscape(letter),
+            rightMargin=18,
+            leftMargin=18,
+            topMargin=18,
+            bottomMargin=18,
+        )
+        table = Table(rows, repeatRows=1)
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 8),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+                ]
+            )
+        )
+        doc.build([table])
+    else:
+        latest.to_csv(output_path)
 
 
 def main() -> None:
@@ -106,18 +148,50 @@ def main() -> None:
         default="historic_prices_sample.csv",
         help="Input OHLCV CSV file",
     )
+    out_grp = p.add_mutually_exclusive_group()
+    out_grp.add_argument(
+        "--excel",
+        action="store_true",
+        help="Save the summary as an Excel workbook instead of CSV.",
+    )
+    out_grp.add_argument(
+        "--pdf",
+        action="store_true",
+        help="Save the summary as a PDF report instead of CSV.",
+    )
     p.add_argument(
         "-o",
         "--output",
         default=DEFAULT_OUTPUT,
-        help="Path to save the summary CSV",
+        help="Path to save the summary file",
     )
     args = p.parse_args()
 
+    if not args.excel and not args.pdf:
+        try:
+            choice = (
+                input("Select output format [csv / excel / pdf] (default csv): ")
+                .strip()
+                .lower()
+            )
+        except EOFError:
+            choice = ""
+        if choice in {"excel", "xlsx"}:
+            args.excel = True
+        elif choice == "pdf":
+            args.pdf = True
+
+    fmt = "excel" if args.excel else "pdf" if args.pdf else "csv"
+    output_path = args.output
+    if fmt == "excel" and output_path.endswith(".csv"):
+        output_path = output_path[:-4] + ".xlsx"
+    elif fmt == "pdf" and output_path.endswith(".csv"):
+        output_path = output_path[:-4] + ".pdf"
+
     df = pd.read_csv(args.csv, parse_dates=["date"])
     df = compute_indicators(df)
-    generate_report(df, args.output)
-    print(f"✅  Saved report → {args.output}")
+    generate_report(df, output_path, fmt)
+    print(f"✅  Saved report → {output_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix `vwap` calculation in `daily_pulse.py`
- allow PDF and Excel output for `daily_pulse.py`
- document new `daily_pulse.py` script in README

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q yfinance`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684926c172d8832eac7e77b4746c6b50