### PR TITLE
Add orchestrator and live feed PDF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | Script | Description |
 | ------ | ----------- |
 | `historic_prices.py` | Downloads the last 60 days of daily OHLCV data for tickers read from `tickers_live.txt` or `tickers.txt`. If IBKR is reachable, the current account holdings are used as the ticker list. The output is a timestamped CSV in `~/Library/Mobile\ Documents/.../Downloads`. Use `--excel` or `--pdf` to save as those formats instead. |
-| `live_feed.py` | Takes a snapshot of real‑time quotes for tickers listed in `tickers_live.txt` (falling back to `tickers.txt`). Quotes are pulled from IBKR when available, otherwise from yfinance and FRED. Results are written to `live_quotes_YYYYMMDD_HHMM.csv`. |
+| `live_feed.py` | Takes a snapshot of real‑time quotes for tickers listed in `tickers_live.txt` (falling back to `tickers.txt`). Quotes are pulled from IBKR when available, otherwise from yfinance and FRED. Results are written to `live_quotes_YYYYMMDD_HHMM.csv`. Use `--pdf` to save a PDF report instead. |
 | `tech_signals_ibkr.py` | Calculates technical indicators using IBKR data and includes option chain details like open interest (fetched from Yahoo Finance) and near‑ATM implied volatility. |
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
 | `daily_pulse.py` | Generates a one-row-per-ticker summary of technical indicators from an OHLCV CSV. Defaults to CSV output; use `--excel` or `--pdf` for other formats. |
@@ -20,6 +20,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | `option_chain_snapshot.py` | Saves a complete IBKR option chain for the portfolio or given symbols. Defaults to CSV; use `--excel` or `--pdf` to change the output type. |
 | `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. Supports `--excel` and `--pdf` outputs. |
 | `trades_report.py` | Exports executions and open orders from IBKR to CSV for a chosen date range. Add `--excel` or `--pdf` for formatted reports. |
+| `orchestrate_dataset.py` | Runs the main export scripts in sequence (`historic_prices.py`, `portfolio_greeks.py`, `live_feed.py`, and `daily_pulse.py`) and zips the results into `dataset_<DATE_TIME>.zip`. |
 
 ### CP_REFRESH_TOKEN
 `net_liq_history_export.py` looks for the environment variable `CP_REFRESH_TOKEN` when pulling data from the Client Portal API. Set it before running the script:

--- a/orchestrate_dataset.py
+++ b/orchestrate_dataset.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+import sys
+import zipfile
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import List
+
+from historic_prices import OUTPUT_DIR
+
+
+def run_script(cmd: list[str]) -> List[str]:
+    """Run a script and return newly created files in OUTPUT_DIR."""
+    before = set(os.listdir(OUTPUT_DIR))
+    subprocess.run([sys.executable, *cmd], check=True)
+    after = set(os.listdir(OUTPUT_DIR))
+    return [os.path.join(OUTPUT_DIR, f) for f in after - before]
+
+
+def create_zip(files: List[str], dest: str) -> None:
+    """Create a zip archive containing the given files."""
+    with zipfile.ZipFile(dest, "w") as zf:
+        for path in files:
+            zf.write(path, os.path.basename(path))
+
+
+def main() -> None:
+    try:
+        choice = input("Output format [csv/pdf] (default csv): ").strip().lower()
+    except EOFError:
+        choice = ""
+    fmt = "pdf" if choice == "pdf" else "csv"
+
+    flag = ["--pdf"] if fmt == "pdf" else []
+    files: List[str] = []
+    files += run_script(["historic_prices.py", *flag])
+    files += run_script(["portfolio_greeks.py", *flag])
+    files += run_script(["live_feed.py", *flag])
+    files += run_script(["daily_pulse.py", "--filetype", fmt])
+
+    ts = datetime.now(ZoneInfo("Europe/Istanbul")).strftime("%Y%m%d_%H%M")
+    dest = os.path.join(OUTPUT_DIR, f"dataset_{ts}.zip")
+    create_zip(files, dest)
+    print(f"Created {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_orchestrate_dataset.py
+++ b/tests/test_orchestrate_dataset.py
@@ -1,0 +1,44 @@
+import unittest
+from pathlib import Path
+import tempfile
+
+import orchestrate_dataset as od
+
+
+class OrchestrateTests(unittest.TestCase):
+    def test_run_script_collects_new_files(self):
+        tmp = Path("./tmp_test_run")
+        tmp.mkdir(exist_ok=True)
+        self.addCleanup(lambda: [p.unlink() for p in tmp.iterdir()])
+        od.OUTPUT_DIR = str(tmp)
+
+        def dummy_run(cmd, check):
+            (tmp / "new.csv").write_text("x")
+
+        prev = od.subprocess.run
+        od.subprocess.run = dummy_run
+        try:
+            created = od.run_script(["dummy.py"])
+        finally:
+            od.subprocess.run = prev
+        self.assertEqual(len(created), 1)
+        self.assertTrue((tmp / "new.csv") in map(Path, created))
+
+    def test_create_zip(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            f1 = td_path / "a.txt"
+            f2 = td_path / "b.txt"
+            f1.write_text("1")
+            f2.write_text("2")
+            zip_path = td_path / "out.zip"
+            od.create_zip([str(f1), str(f2)], str(zip_path))
+            self.assertTrue(zip_path.exists())
+            import zipfile
+
+            with zipfile.ZipFile(zip_path) as zf:
+                self.assertEqual(set(zf.namelist()), {"a.txt", "b.txt"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `orchestrate_dataset.py` to run core export scripts and bundle results
- support `--pdf` output in `live_feed.py`
- document new script and updated `live_feed.py` usage
- test orchestration helpers

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pip install reportlab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd33918a4832e8f404406b2dd369a