### PR TITLE
Add progress bar to orchestrator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ib_insync
 tqdm
 pandas_datareader
 requests
+rich

--- a/tests/test_orchestrate_dataset.py
+++ b/tests/test_orchestrate_dataset.py
@@ -13,7 +13,7 @@ class OrchestrateTests(unittest.TestCase):
         self.addCleanup(lambda: [p.unlink() for p in tmp.iterdir()])
         od.OUTPUT_DIR = str(tmp)
 
-        def dummy_run(cmd, check):
+        def dummy_run(cmd, check, stdout=None, stderr=None):
             (tmp / "new.csv").write_text("x")
 
         prev = od.subprocess.run


### PR DESCRIPTION
## Summary
- hide script output and show nested progress bars when running the dataset orchestrator
- update tests for new `run_script` signature
- add `rich` as dependency

## Testing
- `pip install -q rich`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdf364bb0832ea0a568564ea0b895