### PR TITLE
Add rich progress bars

### DIFF
--- a/daily_pulse.py
+++ b/daily_pulse.py
@@ -16,7 +16,7 @@ import logging
 import warnings
 import io
 import contextlib
-from tqdm import tqdm  # progress bar
+from utils.progress import iter_progress
 from reportlab.lib.pagesizes import letter, landscape  # PDF output (landscape added)
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Spacer
 from reportlab.lib import colors
@@ -158,7 +158,7 @@ def fetch_ohlc(tickers, days_back=60) -> pd.DataFrame:
         progress=False,
     )
     rows = []
-    for t in tqdm(tickers, desc="Processing tickers"):
+    for t in iter_progress(tickers, "Processing tickers"):
         d = data[t].dropna().reset_index()
         d.columns = ["date", "open", "high", "low", "close", "adj_close", "volume"]
         d["ticker"] = t

--- a/historic_prices.py
+++ b/historic_prices.py
@@ -18,10 +18,10 @@ except Exception:  # pragma: no cover - optional
 
 # optional progress bar
 try:
-    from tqdm import tqdm
+    from utils.progress import iter_progress
 
     PROGRESS = True
-except ImportError:
+except Exception:  # pragma: no cover - optional
     PROGRESS = False
 from datetime import datetime
 
@@ -111,7 +111,7 @@ def fetch_and_prepare_data(tickers):
         return pd.DataFrame(columns=columns)
     dfs = []
     if isinstance(data.columns, pd.MultiIndex):
-        iterable = tqdm(tickers, desc="split") if PROGRESS else tickers
+        iterable = iter_progress(tickers, "split") if PROGRESS else tickers
         for ticker in iterable:
             if ticker in data:
                 df_t = data[ticker].reset_index()

--- a/live_feed.py
+++ b/live_feed.py
@@ -36,10 +36,10 @@ except Exception:  # pragma: no cover - optional
 
 # optional progress bar
 try:
-    from tqdm import tqdm
+    from utils.progress import iter_progress
 
     PROGRESS = True
-except ImportError:
+except Exception:  # pragma: no cover - optional
     PROGRESS = False
 
 try:
@@ -203,7 +203,7 @@ def fetch_ib_quotes(tickers: list[str], opt_cons: list[Option]) -> pd.DataFrame:
     reqs: dict[str, any] = {}
 
     # Build contracts & request market data
-    iterable = tqdm(tickers, desc="IB snapshots") if PROGRESS else tickers
+    iterable = iter_progress(tickers, "IB snapshots") if PROGRESS else tickers
     for tk in iterable:
         # Skip continuous futures (=F) and Yahoo-only yield symbols – use yfinance
         if tk.endswith("=F") or tk in YIELD_MAP:
@@ -291,7 +291,7 @@ def fetch_ib_quotes(tickers: list[str], opt_cons: list[Option]) -> pd.DataFrame:
 def fetch_yf_quotes(tickers: list[str]) -> pd.DataFrame:
     rows = []
     ts = datetime.utcnow().isoformat(timespec="seconds") + "Z"
-    iterable = tqdm(tickers, desc="yfinance") if PROGRESS else tickers
+    iterable = iter_progress(tickers, "yfinance") if PROGRESS else tickers
     for t in iterable:
         if t in YIELD_MAP:
             continue  # yields fetched via FRED
@@ -343,7 +343,7 @@ def fetch_fred_yields(tickers: list[str]) -> pd.DataFrame:
         return pd.DataFrame()
     rows = []
     ts = datetime.utcnow().isoformat(timespec="seconds") + "Z"
-    iterable = tqdm(tickers, desc="FRED") if PROGRESS else tickers
+    iterable = iter_progress(tickers, "FRED") if PROGRESS else tickers
     for t in iterable:
         series = YIELD_MAP.get(t)
         if not series:

--- a/option_chain_snapshot.py
+++ b/option_chain_snapshot.py
@@ -135,10 +135,10 @@ for _n in ("ib_insync", "ib_insync.ib", "ib_insync.wrapper"):
 
 # optional progress bar
 try:
-    from tqdm import tqdm
+    from utils.progress import iter_progress
 
     PROGRESS = True
-except ImportError:
+except Exception:  # pragma: no cover - optional
     PROGRESS = False
 
 # ---------------------------------------------------------------------------
@@ -737,7 +737,7 @@ def main():
         expiry_hint = hint or None
 
     logger.info("Symbols: %s", ", ".join(symbols))
-    iterable = tqdm(symbols, desc="Option snapshots") if PROGRESS else symbols
+    iterable = iter_progress(symbols, "Option snapshots") if PROGRESS else symbols
 
     date_tag = datetime.now(ZoneInfo("Europe/Istanbul")).strftime("%Y%m%d_%H%M")
     combined = []

--- a/portfolio_greeks.py
+++ b/portfolio_greeks.py
@@ -53,11 +53,11 @@ from ib_insync import Future, IB, Index, Option, Position, Stock, Ticker, util
 from ib_insync.contract import Contract
 
 try:
-    from tqdm import tqdm
+    from utils.progress import iter_progress
 
     # Re‑enable progress‑bar printing
     PROGRESS = True
-except ImportError:
+except Exception:  # pragma: no cover - optional
     PROGRESS = False
 
 # ────────────────────── logging setup (must precede helpers) ─────────────────────
@@ -368,7 +368,9 @@ def _save_pdf(df: pd.DataFrame, totals: pd.DataFrame, path: str) -> None:
 
     totals_fmt = totals.copy()
     float_cols_tot = totals_fmt.select_dtypes(include=[float]).columns
-    totals_fmt[float_cols_tot] = totals_fmt[float_cols_tot].applymap(lambda x: f"{x:,.3f}")
+    totals_fmt[float_cols_tot] = totals_fmt[float_cols_tot].applymap(
+        lambda x: f"{x:,.3f}"
+    )
     totals_data = [totals_fmt.columns.tolist()] + totals_fmt.values.tolist()
 
     doc = SimpleDocTemplate(
@@ -416,13 +418,18 @@ def _save_pdf(df: pd.DataFrame, totals: pd.DataFrame, path: str) -> None:
             TableStyle(
                 [
                     ("BACKGROUND", (0, 0), (-1, 0), colors.darkblue),
-                    ("TEXTCOLOR",   (0, 0), (-1, 0), colors.whitesmoke),
-                    ("ALIGN",       (0, 0), (-1, 0), "CENTER"),
-                    ("ALIGN",       (0, 1), (-1, -1), "RIGHT"),
-                    ("FONTSIZE",    (0, 0), (-1, 0), 8),
-                    ("FONTSIZE",    (0, 1), (-1, -1), 7),
-                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.whitesmoke, colors.lightgrey]),
-                    ("GRID",        (0, 0), (-1, -1), 0.25, colors.black),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("ALIGN", (0, 0), (-1, 0), "CENTER"),
+                    ("ALIGN", (0, 1), (-1, -1), "RIGHT"),
+                    ("FONTSIZE", (0, 0), (-1, 0), 8),
+                    ("FONTSIZE", (0, 1), (-1, -1), 7),
+                    (
+                        "ROWBACKGROUNDS",
+                        (0, 1),
+                        (-1, -1),
+                        [colors.whitesmoke, colors.lightgrey],
+                    ),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
                 ]
             )
         )
@@ -435,12 +442,12 @@ def _save_pdf(df: pd.DataFrame, totals: pd.DataFrame, path: str) -> None:
         TableStyle(
             [
                 ("BACKGROUND", (0, 0), (-1, 0), colors.darkgreen),
-                ("TEXTCOLOR",   (0, 0), (-1, 0), colors.whitesmoke),
-                ("ALIGN",       (0, 0), (-1, 0), "CENTER"),
-                ("ALIGN",       (0, 1), (-1, -1), "RIGHT"),
-                ("FONTSIZE",    (0, 0), (-1, 0), 9),
-                ("FONTSIZE",    (0, 1), (-1, -1), 8),
-                ("GRID",        (0, 0), (-1, -1), 0.3, colors.black),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                ("ALIGN", (0, 0), (-1, 0), "CENTER"),
+                ("ALIGN", (0, 1), (-1, -1), "RIGHT"),
+                ("FONTSIZE", (0, 0), (-1, 0), 9),
+                ("FONTSIZE", (0, 1), (-1, -1), 8),
+                ("GRID", (0, 0), (-1, -1), 0.3, colors.black),
             ]
         )
     )
@@ -552,7 +559,7 @@ def main() -> None:
     rows: List[Dict[str, Any]] = []
     yf_oi_cache: Dict[tuple[str, str], dict[tuple[float, str], int]] = {}
 
-    iterable = tqdm(pkgs, desc="Processing portfolio greeks") if PROGRESS else pkgs
+    iterable = iter_progress(pkgs, "Processing portfolio greeks") if PROGRESS else pkgs
     for pos, tk in iterable:
         c: Contract = pos.contract
         mult = _multiplier(c)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ yfinance
 pandas
 numpy
 ib_insync
-tqdm
 pandas_datareader
 requests
 rich

--- a/tech_signals_ibkr.py
+++ b/tech_signals_ibkr.py
@@ -28,10 +28,10 @@ import yfinance as yf
 
 # optional progress bar
 try:
-    from tqdm import tqdm
+    from utils.progress import iter_progress
 
     PROGRESS = True
-except ImportError:
+except Exception:  # pragma: no cover - optional
     PROGRESS = False
 # Symbol → (Contract class, kwargs) for non‑stock underlyings
 from ib_insync import Index, Future  # already imported IB, Stock, Option, util
@@ -269,7 +269,7 @@ if not spy_ret.empty:
     # drop timezone info so date intersections succeed
     spy_ret.index = pd.to_datetime(spy_ret.index).tz_localize(None)
 
-iterable = tqdm(tickers, desc="tech signals") if PROGRESS else tickers
+iterable = iter_progress(tickers, "tech signals") if PROGRESS else tickers
 for tk in iterable:
     logging.info("▶ %s", tk)
     if tk == "MOVE":

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator, TypeVar
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+
+T = TypeVar("T")
+
+
+def iter_progress(iterable: Iterable[T], description: str) -> Iterator[T]:
+    """Yield items from *iterable* with a Rich progress bar."""
+    items = list(iterable)
+    console = Console(force_terminal=True)
+    progress = Progress(
+        SpinnerColumn(),
+        BarColumn(),
+        TextColumn(description),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+        transient=True,
+    )
+    with progress:
+        task = progress.add_task(description, total=len(items))
+        for item in items:
+            yield item
+            progress.advance(task)


### PR DESCRIPTION
## Summary
- swap tqdm for a new `iter_progress` helper that uses Rich
- remove tqdm from dependencies
- show progress bars in all scripts via Rich

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fec58ab5c832eacd90ba8c5b2dfed