### PR TITLE
Zip option chain snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
 | `daily_pulse.py` | Generates a one-row-per-ticker summary of technical indicators from an OHLCV CSV. Defaults to CSV output; use `--excel` or `--pdf` for other formats. |
 | `portfolio_greeks.py` | Exports per-position Greeks and account totals using IBKR market data, producing `portfolio_greeks_<YYYYMMDD_HHMM>.csv` and a totals file. Pass `--excel` or `--pdf` for alternative formats. |
-| `option_chain_snapshot.py` | Saves a complete IBKR option chain for the portfolio or given symbols. Defaults to CSV; use `--excel` or `--pdf` to change the output type. |
+| `option_chain_snapshot.py` | Saves a complete IBKR option chain for the portfolio or given symbols. Results are zipped into `option_chain_<DATE_TIME>.zip` and the original files are removed. Defaults to CSV; use `--excel` or `--pdf` to change the output type. |
 | `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. Supports `--excel` and `--pdf` outputs. |
 | `trades_report.py` | Exports executions and open orders from IBKR to CSV for a chosen date range. Add `--excel` or `--pdf` for formatted reports. |
 | `orchestrate_dataset.py` | Runs the main export scripts in sequence (`historic_prices.py`, `portfolio_greeks.py`, `live_feed.py`, and `daily_pulse.py`), zips the results into `dataset_<DATE_TIME>.zip`, and deletes the individual files. |

--- a/tests/test_option_chain_snapshot.py
+++ b/tests/test_option_chain_snapshot.py
@@ -3,6 +3,9 @@ import types
 import unittest
 from unittest.mock import patch
 from datetime import datetime, timedelta
+from pathlib import Path
+import tempfile
+import zipfile
 
 # Provide minimal stubs so import works without optional packages
 try:
@@ -103,6 +106,23 @@ class YFinanceFallbackTests(unittest.TestCase):
             data = oc.fetch_yf_open_interest("AAA", "20240101")
         self.assertEqual(data[(100.0, "C")], 10)
         self.assertEqual(data[(90.0, "P")], 5)
+
+
+class ZipHelpersTests(unittest.TestCase):
+    def test_create_zip_and_cleanup(self):
+        with tempfile.TemporaryDirectory() as td:
+            p1 = Path(td) / "a.txt"
+            p2 = Path(td) / "b.txt"
+            p1.write_text("1")
+            p2.write_text("2")
+            zip_path = Path(td) / "out.zip"
+            oc.create_zip([str(p1), str(p2)], str(zip_path))
+            self.assertTrue(zip_path.exists())
+            with zipfile.ZipFile(zip_path) as zf:
+                self.assertEqual(set(zf.namelist()), {"a.txt", "b.txt"})
+            oc.cleanup([str(p1), str(p2)])
+            self.assertFalse(p1.exists())
+            self.assertFalse(p2.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- bundle option chain exports into a zip archive
- clean up individual files after zipping
- document new behaviour in README
- add tests for zip helper utilities

## Testing
- `pip install -r requirements-dev.txt`
- `pip install yfinance rich reportlab ib_insync`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501e0fb79c832e83ce7a0a6992357c