### PR TITLE
Harden CLI and add smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here are some common usage examples:
 
 ```bash
 # Generate a daily pulse report
-python main.py pulse --tickers "AAPL,MSFT,GOOG" --output pulse.csv
+python main.py pulse --tickers "AAPL,MSFT,GOOG" --output pulse.csv --output-dir ~/Downloads
 
 # Fetch portfolio positions, grouped by combo
 python main.py positions --group-by-combo
@@ -45,13 +45,13 @@ python main.py positions --group-by-combo
 python main.py portfolio-greeks
 
 # Grab a live quote snapshot
-python main.py live
+python main.py live --format pdf
 
 # Interactively choose symbols and expiries for option chain
-python main.py options --symbol SPY
+python main.py options --tickers SPY
 
 # Option-chain snapshot for specific symbols and expiries
-python main.py options --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
+python main.py options --tickers TSLA,AAPL --expiries 20250620
 
 # Export today's executions and open orders
 python main.py report --today

--- a/src/data_fetching.py
+++ b/src/data_fetching.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import logging
 import math
 import time
 from datetime import datetime, timedelta, timezone, date
@@ -11,6 +10,8 @@ import os
 import pandas as pd
 import numpy as np
 import yfinance as yf
+
+TEST_MODE = os.getenv("PE_TEST_MODE") == "1"
 
 try:
     from ib_insync import IB, Option, Stock, Forex, Index
@@ -1082,3 +1083,16 @@ def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.Da
     )
 
     return df
+
+
+if TEST_MODE:
+    from . import offline as _offline
+
+    fetch_ohlc = _offline.fetch_ohlc
+    fetch_ib_quotes = _offline.fetch_ib_quotes
+    fetch_yf_quotes = _offline.fetch_yf_quotes
+    snapshot_chain = _offline.snapshot_chain
+    load_ib_positions_ib = _offline.load_ib_positions_ib
+    list_positions = _offline.list_positions
+    get_portfolio_contracts = _offline.get_portfolio_contracts
+    IB = _offline.DummyIB  # type: ignore

--- a/src/offline.py
+++ b/src/offline.py
@@ -1,0 +1,112 @@
+import pandas as pd
+from typing import List, Tuple
+
+
+class DummyIB:
+    def __init__(self):
+        self.connected = False
+
+    def connect(self, *a, **k):
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
+
+    def positions(self):
+        return []
+
+    def isConnected(self):
+        return self.connected
+
+
+class DummyContract:
+    def __init__(self, symbol: str):
+        self.symbol = symbol
+        self.secType = "STK"
+        self.conId = 1
+
+
+class DummyPos:
+    def __init__(self, symbol: str):
+        self.contract = DummyContract(symbol)
+        self.position = 1
+
+
+class DummyTicker:
+    def __init__(self):
+        g = type(
+            "Greeks", (), dict(delta=0.5, gamma=0.1, vega=0.2, theta=0.1, rho=0.0)
+        )()
+        self.modelGreeks = g
+
+
+# sample small dataframe helpers
+
+
+def fetch_ohlc(tickers: List[str], days_back: int = 60) -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=2, freq="D").strftime("%Y-%m-%d")
+    rows = []
+    for t in tickers:
+        for i, d in enumerate(dates):
+            rows.append(
+                {
+                    "date": d,
+                    "ticker": t,
+                    "open": i,
+                    "high": i + 1,
+                    "low": i,
+                    "close": i + 0.5,
+                    "adj_close": i + 0.5,
+                    "volume": 100,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def fetch_ib_quotes(ib, contracts) -> pd.DataFrame:
+    rows = []
+    for i, c in enumerate(contracts):
+        sym = getattr(c, "symbol", f"C{i}")
+        rows.append({"ticker": sym, "last": 1.0, "source": "IB"})
+    return pd.DataFrame(rows)
+
+
+def fetch_yf_quotes(tickers: List[str]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ticker": tickers,
+            "last": [1.0] * len(tickers),
+            "source": ["YF"] * len(tickers),
+        }
+    )
+
+
+def snapshot_chain(ib, symbol: str, expiry_hint: str | None = None) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "symbol": [symbol],
+            "expiry": [expiry_hint or "20250101"],
+            "strike": [100.0],
+            "right": ["C"],
+        }
+    )
+
+
+def load_ib_positions_ib(*a, **k) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "symbol": ["AAPL"],
+            "side": ["Long"],
+            "quantity": [1],
+            "cost basis": [1.0],
+            "mark price": [1.1],
+        }
+    )
+
+
+def list_positions(ib) -> List[Tuple[DummyPos, DummyTicker]]:
+    return [(DummyPos("AAPL"), DummyTicker())]
+
+
+def get_portfolio_contracts(ib) -> List[DummyContract]:
+    return [DummyContract("AAPL")]

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Iterable, Iterator, List
 import pandas as pd
+import sys
 from rich.console import Console
 from rich.progress import (
     BarColumn,
@@ -24,7 +25,7 @@ _PASTEL_THEME = Theme(
     }
 )
 
-_console = Console(theme=_PASTEL_THEME, force_terminal=True)
+_console = Console(file=sys.stderr, theme=_PASTEL_THEME, force_terminal=False)
 
 
 def progress_bar(iterable: Iterable, description: str) -> Iterator:

--- a/tests/test_calc_portfolio_greeks.py
+++ b/tests/test_calc_portfolio_greeks.py
@@ -1,0 +1,14 @@
+import pandas as pd
+from src import analysis
+
+
+def test_calc_portfolio_greeks_equities_only():
+    df = pd.DataFrame({"underlying": ["AAPL"], "position": [10], "multiplier": [1]})
+    res = analysis.calc_portfolio_greeks(df)
+    assert "PORTFOLIO" in res.index
+    assert res.loc["PORTFOLIO", "delta"] == 0
+
+
+def test_calc_portfolio_greeks_empty():
+    res = analysis.calc_portfolio_greeks(pd.DataFrame())
+    assert res.empty

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+import pytest
+
+COMMANDS = [
+    ["pulse", "--tickers", "AAPL"],
+    ["live", "--tickers", "AAPL", "--format", "pdf"],
+    ["options", "--tickers", "AAPL", "--expiries", "20250101"],
+    ["positions"],
+    ["report", "--input", "sample_trades.csv", "--format", "pdf"],
+    ["portfolio-greeks"],
+    ["orchestrate"],
+]
+
+
+@pytest.mark.parametrize("args", COMMANDS)
+def test_cli_command(args, tmp_path):
+    env = os.environ.copy()
+    env["PE_TEST_MODE"] = "1"
+    env["OUTPUT_DIR"] = str(tmp_path)
+    cmd = [sys.executable, "main.py", "--output-dir", str(tmp_path), *args]
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert any(tmp_path.iterdir())
+
+
+def test_interactive_exit(tmp_path):
+    env = os.environ.copy()
+    env["PE_TEST_MODE"] = "1"
+    env["OUTPUT_DIR"] = str(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, "main.py", "--output-dir", str(tmp_path)],
+        input="8\n",
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    assert proc.returncode == 0

--- a/tests/test_ib_fallback.py
+++ b/tests/test_ib_fallback.py
@@ -1,0 +1,21 @@
+import logging
+import pandas as pd
+from unittest.mock import patch
+
+from src import utils
+
+
+def test_ib_first_quote_fallback(caplog):
+    class DummyIB:
+        def connect(self, *a, **k):
+            raise TimeoutError
+
+    def fake_yf(tickers):
+        return pd.DataFrame({"ticker": tickers, "last": [1.0] * len(tickers)})
+
+    with patch("src.utils.data_fetching.IB", return_value=DummyIB()):
+        with patch("src.utils.data_fetching.fetch_yf_quotes", fake_yf):
+            caplog.set_level(logging.WARNING)
+            df = utils.ib_first_quote(["AAA"], ib_timeout=0.1)
+    assert not df.empty
+    assert "IBKR quote fetch failed" in caplog.text

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, Iterator, TypeVar
+import sys
 
 from rich.console import Console
 from rich.progress import (
@@ -18,7 +19,7 @@ T = TypeVar("T")
 def iter_progress(iterable: Iterable[T], description: str) -> Iterator[T]:
     """Yield items from *iterable* with a Rich progress bar."""
     items = list(iterable)
-    console = Console(force_terminal=True)
+    console = Console(file=sys.stderr, force_terminal=False)
     progress = Progress(
         SpinnerColumn(),
         BarColumn(),


### PR DESCRIPTION
## Summary
- create offline data stubs for tests
- make OUTPUT_DIR configurable via flag
- allow option snapshots with multi‑ticker flags
- handle trades report without missing helper
- fix progress bar behaviour for non‑TTY
- add smoke tests for CLI and new unit tests
- document new CLI usage

## Testing
- `pytest -q`
- `python main.py --output-dir out pulse --tickers AAPL`
- `PE_TEST_MODE=1 python main.py --output-dir out live --tickers AAPL --format pdf`
- `PE_TEST_MODE=1 python main.py --output-dir out options --tickers AAPL --expiries 20250101`
- `PE_TEST_MODE=1 python main.py --output-dir out positions`
- `PE_TEST_MODE=1 python main.py --output-dir out report --input sample_trades.csv --format pdf`
- `PE_TEST_MODE=1 python main.py --output-dir out portfolio-greeks`
- `PE_TEST_MODE=1 python main.py --output-dir out orchestrate --format csv`


------
https://chatgpt.com/codex/tasks/task_e_686520a45284832e80415cb2ea470312