### PR TITLE
feat: unified config with .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+CP_REFRESH_TOKEN=""

--- a/portfolio_exporter/config/settings.yaml
+++ b/portfolio_exporter/config/settings.yaml
@@ -1,0 +1,4 @@
+output_dir: "~/Downloads/portfolio_exports"
+timezone: "Europe/Istanbul"
+broker: "IBKR"
+default_account: "UXXXXXXX"

--- a/portfolio_exporter/core/config.py
+++ b/portfolio_exporter/core/config.py
@@ -1,0 +1,12 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    output_dir: str = "~/Downloads/portfolio_exports"
+    timezone: str = "Europe/Istanbul"
+    broker: str = "IBKR"
+    default_account: str = "UXXXXXXX"
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+settings = Settings()  # singleton

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,5 @@
+from portfolio_exporter.core.config import settings
+
+
+def test_timezone():
+    assert settings.timezone == "Europe/Istanbul"


### PR DESCRIPTION
## Summary
- add YAML config with default settings
- expose settings singleton via `pydantic-settings`
- provide example `.env` file
- test timezone from config

## Testing
- `pip install --quiet -r requirements-dev.txt`
- `pip install --quiet -r requirements.txt`
- `pip install --quiet pydantic-settings reportlab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e77a53f28832eac016e68640b34b0