### PR TITLE
Add global Rich status bar and integrate into CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ import sys
 from rich.console import Console
 from rich.table import Table
 
+from portfolio_exporter.core.ui import StatusBar
+
 console = Console()
 
 
@@ -36,18 +38,29 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+    status = None
     if not args.quiet:
-        console.rule("[bold cyan]AI-Managed Playbook[/]")
+        status = StatusBar("Ready")
+        status.update("Ready")
+        console.rule("[bold cyan]AI-Managed Playbook")
 
     while True:
         build_menu()
         choice = input("Select › ").strip()
         if choice == "0":
-            sys.exit(0)
+            break
         elif choice not in {"1", "2", "3"}:
-            console.print("[red]Invalid choice[/]")
+            console.print("[red]Invalid choice")
         else:
-            console.print(f"(stub) You chose {choice}")
+            if choice == "1":
+                if status:
+                    status.update("Pre-Market menu (stub)", "cyan")
+                console.print("(stub) You chose Pre-Market")
+            else:
+                console.print(f"(stub) You chose {choice}")
+
+    if status:
+        status.stop()
 
 
 if __name__ == "__main__":

--- a/portfolio_exporter/core/ui.py
+++ b/portfolio_exporter/core/ui.py
@@ -1,0 +1,29 @@
+from rich.live import Live
+from rich.panel import Panel
+from rich.align import Align
+from rich.console import Console
+
+console = Console()
+
+
+class StatusBar:
+    """Singleton Rich.Live status bar shown at the bottom of the TUI."""
+
+    def __init__(self, text: str = "Ready", style: str = "green"):
+        self._text = text
+        self._style = style
+        self._live = Live(self._render(), console=console, transient=False)
+        self._live.__enter__()  # start live context
+
+    # --- public API ----------------------------------------------------
+    def update(self, text: str, style: str = "green") -> None:
+        self._text, self._style = text, style
+        self._live.update(self._render())
+
+    def stop(self) -> None:
+        self._live.__exit__(None, None, None)
+
+    # --- helpers -------------------------------------------------------
+    def _render(self):
+        panel = Panel(Align.left(self._text), style=self._style, padding=(0, 1))
+        return panel

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,25 @@
+import builtins, types
+from portfolio_exporter.core import ui
+
+
+class Dummy:
+    def __init__(self):
+        self.calls = []
+
+    def update(self, text, style="green"):
+        self.calls.append((text, style))
+
+    def stop(self):
+        pass
+
+
+def test_status_bar_called(monkeypatch):
+    dummy = Dummy()
+    monkeypatch.setattr(ui, "StatusBar", lambda *a, **k: dummy)
+    import importlib, main as m
+
+    importlib.reload(m)  # re-run main with patch
+    m.parse_args = lambda: types.SimpleNamespace(quiet=False, format="csv")
+    monkeypatch.setattr(builtins, "input", lambda _: "0")
+    m.main()
+    assert dummy.calls, "StatusBar.update was never called"


### PR DESCRIPTION
## Summary
- implement `StatusBar` for TUI
- wire status bar into CLI when not run with `--quiet`
- test that the status bar is invoked

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pip install -e .`
- `pip install reportlab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e8691fbf0832e922d404bb9097c55