### PR TITLE
feat(menu): Pre-Market menu with full exporter wiring

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,9 @@ import sys
 
 from rich.console import Console
 from rich.table import Table
+from builtins import input as builtin_input
+
+input = builtin_input
 
 from portfolio_exporter.core.ui import StatusBar
 
@@ -54,8 +57,9 @@ def main() -> None:
         else:
             if choice == "1":
                 if status:
-                    status.update("Pre-Market menu (stub)", "cyan")
-                console.print("(stub) You chose Pre-Market")
+                    status.update("Entering Pre-Market", "cyan")
+                from portfolio_exporter.menus import pre
+                pre.launch(status, args.format)
             else:
                 console.print(f"(stub) You chose {choice}")
 

--- a/portfolio_exporter/menus/__init__.py
+++ b/portfolio_exporter/menus/__init__.py
@@ -1,0 +1,3 @@
+from . import pre
+
+__all__ = ["pre"]

--- a/portfolio_exporter/menus/pre.py
+++ b/portfolio_exporter/menus/pre.py
@@ -1,0 +1,41 @@
+from rich.table import Table
+from portfolio_exporter.core.ui import StatusBar
+from portfolio_exporter.scripts import (
+    update_tickers,
+    historic_prices,
+    daily_pulse,
+    option_chain_snapshot,
+    net_liq_history_export,
+    orchestrate_dataset,
+)
+
+
+def launch(status: StatusBar, default_fmt: str):
+    while True:
+        tbl = Table(title="Pre-Market")
+        for key, label in [
+            ("s", "Sync tickers"),
+            ("h", "Historic prices"),
+            ("p", "Daily pulse"),
+            ("o", "Option chain snapshot"),
+            ("n", "Net-Liq history"),
+            ("z", "Run overnight batch"),
+            ("r", "Return"),
+        ]:
+            tbl.add_row(key, label)
+        status.console.print(tbl)
+        choice = input("\u203a ").strip().lower()
+        if choice == "r":
+            break
+        action = {
+            "s": update_tickers.run,
+            "h": historic_prices.run,
+            "p": daily_pulse.run,
+            "o": option_chain_snapshot.run,
+            "n": net_liq_history_export.run,
+            "z": orchestrate_dataset.run,
+        }.get(choice)
+        if action:
+            status.update(f"Running {choice} …", "cyan")
+            action(fmt=default_fmt)
+            status.update("Ready", "green")

--- a/portfolio_exporter/scripts/__init__.py
+++ b/portfolio_exporter/scripts/__init__.py
@@ -1,0 +1,17 @@
+from . import (
+    update_tickers,
+    historic_prices,
+    daily_pulse,
+    option_chain_snapshot,
+    net_liq_history_export,
+    orchestrate_dataset,
+)
+
+__all__ = [
+    "update_tickers",
+    "historic_prices",
+    "daily_pulse",
+    "option_chain_snapshot",
+    "net_liq_history_export",
+    "orchestrate_dataset",
+]

--- a/portfolio_exporter/scripts/daily_pulse.py
+++ b/portfolio_exporter/scripts/daily_pulse.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""
+daily_pulse.py – Yordam's pre‑market overview
+Run at 07:00 Europe/Istanbul. Produces an Excel workbook in iCloud/Downloads.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import pandas as pd
+import yfinance as yf  # pip install yfinance
+
+import csv
+import logging
+import warnings
+import io
+import contextlib
+from portfolio_exporter.core.config import settings
+from utils.progress import iter_progress
+from reportlab.lib.pagesizes import letter, landscape  # PDF output (landscape added)
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Spacer
+from reportlab.lib import colors
+
+# ── Silence noisy libraries ────────────────────────────────────────────────
+logging.getLogger("ib_insync").setLevel(logging.CRITICAL)
+logging.getLogger("yfinance").setLevel(logging.CRITICAL)
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+# --- Interactive Brokers live API ---
+# pip install ib_insync (requires TWS or IB Gateway running with API enabled)
+from ib_insync import IB, util
+
+# --------------------------------------------------------------------------- #
+# CONFIG – edit these two blocks only                                         #
+# --------------------------------------------------------------------------- #
+
+# 1.  Where your *latest* IB CSV lives (auto‑export or manual upload).
+IB_CSV = Path(
+    "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/IB/Latest/"
+)
+
+# 2.  Macro/technical watch‑list & indicators
+MARKET_OVERVIEW = {
+    #   Ticker   : Friendly name
+    "SPY": "S&P 500",
+    "QQQ": "Nasdaq 100",
+    "IWM": "Russell 2000",
+    "VIX": "VIX Index",
+    "DXY": "US Dollar",
+    "TLT": "US 20Y Bond",
+    "IEF": "US 7‑10Y Bond",
+    "GC=F": "Gold Futures",
+    "CL=F": "WTI Oil",
+    "BTC-USD": "Bitcoin",
+}
+
+INDICATORS = [
+    "pct_change",
+    "sma20",
+    "ema20",
+    "rsi14",
+    "macd",
+    "macd_signal",
+    "atr14",
+    "bb_upper",
+    "bb_lower",
+    "real_vol_30",
+]
+
+# --------------------------------------------------------------------------- #
+# HELPER FUNCTIONS                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def load_ib_positions_ib(
+    host: str = "127.0.0.1",
+    port: int = 7497,
+    client_id: int = 999,
+) -> pd.DataFrame:
+    """
+    Pull current portfolio positions directly from Interactive Brokers via
+    the TWS / IB‑Gateway API (ib_insync wrapper).
+
+    Columns returned: symbol · quantity · cost basis · mark price ·
+    market_value · unrealized_pnl
+    """
+    ib = IB()
+    try:
+        ib.connect(host, port, clientId=client_id)
+        # suppress per‑contract error spam from IB
+        ib.errorEvent += lambda *a, **k: None
+    except Exception as e:
+        raise ConnectionError(
+            f"❌ Cannot connect to IB API at {host}:{port}  →  {e}"
+        ) from e
+
+    positions = ib.positions()
+    if not positions:
+        ib.disconnect()
+        raise RuntimeError(
+            "API returned no positions. Confirm account is logged in and the "
+            "API user has permissions."
+        )
+
+    contracts = [p.contract for p in positions]
+    # Request real‑time market data in a single call
+    tickers = ib.reqTickers(*contracts)
+
+    # Build a quick {conId: last_price} map
+    price_map = {}
+    for t in tickers:
+        # fall back to mid‑point if last==0
+        last = t.last if t.last else (t.bid + t.ask) / 2 if (t.bid and t.ask) else None
+        price_map[t.contract.conId] = last
+
+    rows = []
+    for p in positions:
+        symbol = p.contract.symbol
+        qty = p.position
+        cost_basis = p.avgCost
+        mark_price = price_map.get(p.contract.conId)
+        # --- Fallback: try yfinance close if IB API did not return a price
+        if mark_price is None or pd.isna(mark_price):
+            try:
+                yq = yf.Ticker(symbol).history(period="1d")["Close"]
+                mark_price = float(yq.iloc[-1]) if not yq.empty else None
+            except Exception:
+                mark_price = None
+        side = "Short" if qty < 0 else "Long"
+        rows.append(
+            {
+                "symbol": symbol,
+                "side": side,
+                "quantity": abs(qty),
+                "cost basis": cost_basis,
+                "mark price": mark_price,
+            }
+        )
+
+    df = pd.DataFrame(rows)
+    df["market_value"] = df["quantity"] * df["mark price"]
+    df["unrealized_pnl"] = (df["mark price"] - df["cost basis"]) * df["quantity"]
+
+    ib.disconnect()
+    return df
+
+
+def fetch_ohlc(tickers, days_back=60) -> pd.DataFrame:
+    """Download daily OHLCV plus today’s pre‑market quote."""
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days_back)
+    data = yf.download(
+        tickers,
+        start=start.date(),
+        end=end.date() + timedelta(days=1),
+        group_by="ticker",
+        auto_adjust=False,
+        progress=False,
+    )
+    rows = []
+    for t in iter_progress(tickers, "Processing tickers"):
+        d = data[t].dropna().reset_index()
+        d.columns = ["date", "open", "high", "low", "close", "adj_close", "volume"]
+        d["ticker"] = t
+        rows.append(d)
+    return pd.concat(rows, ignore_index=True)
+
+
+def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """(Same logic as your original, condensed & vectorised)"""
+    df = df.sort_values(["ticker", "date"]).copy()
+    grp = df.groupby("ticker", group_keys=False)
+
+    df["pct_change"] = grp["close"].pct_change(fill_method=None)
+    df["sma20"] = grp["close"].transform(lambda s: s.rolling(20).mean())
+    df["ema20"] = grp["close"].transform(lambda s: s.ewm(span=20).mean())
+
+    # RSI14
+    delta = grp["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    rs = gain.rolling(14).mean() / loss.rolling(14).mean()
+    df["rsi14"] = 100 - 100 / (1 + rs)
+
+    # MACD
+    ema12 = grp["close"].transform(lambda s: s.ewm(span=12).mean())
+    ema26 = grp["close"].transform(lambda s: s.ewm(span=26).mean())
+    df["macd"] = ema12 - ema26
+    df["macd_signal"] = grp["macd"].transform(lambda s: s.ewm(span=9).mean())
+
+    # ATR14
+    tr = (
+        (df["high"] - df["low"])
+        .abs()
+        .to_frame("hl")
+        .join((df["high"] - grp["close"].shift()).abs().to_frame("hc"))
+        .join((df["low"] - grp["close"].shift()).abs().to_frame("lc"))
+        .max(axis=1)
+    )
+    df["atr14"] = grp.apply(
+        lambda g: tr.loc[g.index].rolling(14).mean(), include_groups=False
+    )
+
+    # Bollinger
+    m20 = df["sma20"]
+    std20 = grp["close"].transform(lambda s: s.rolling(20).std())
+    df["bb_upper"] = m20 + 2 * std20
+    df["bb_lower"] = m20 - 2 * std20
+
+    df["vwap"] = (df["close"] * df["volume"]).groupby(df["ticker"]).cumsum() / df[
+        "volume"
+    ].groupby(df["ticker"]).cumsum()
+
+    # Realised vol 30d
+    df["real_vol_30"] = grp["pct_change"].transform(
+        lambda s: s.rolling(30).std() * (252**0.5)
+    )
+    return df
+
+
+def last_row(df: pd.DataFrame) -> pd.DataFrame:
+    return df.sort_values("date").groupby("ticker").tail(1).set_index("ticker")
+
+
+def generate_report(df: pd.DataFrame, output_path: str, fmt: str = "csv") -> None:
+    """Write the latest metrics for each ticker to ``output_path``."""
+    latest = (
+        df.sort_values("date")
+        .groupby("ticker", as_index=False)
+        .tail(1)
+        .set_index("ticker", drop=True)
+    )
+
+    cols = [
+        "close",
+        "pct_change",
+        "sma20",
+        "ema20",
+        "atr14",
+        "rsi14",
+        "macd",
+        "macd_signal",
+        "bb_upper",
+        "bb_lower",
+        "vwap",
+        "real_vol_30",
+    ]
+
+    cols = [c for c in cols if c in latest.columns]
+    latest = latest[cols].round(3)
+
+    if fmt == "excel":
+        with pd.ExcelWriter(
+            output_path, engine="xlsxwriter", datetime_format="yyyy-mm-dd"
+        ) as writer:
+            latest.reset_index().to_excel(
+                writer, sheet_name="Pulse", index=False, float_format="%.3f"
+            )
+    elif fmt == "pdf":
+        if SimpleDocTemplate is None:
+            raise RuntimeError("reportlab is required for PDF output")
+        rows = [
+            latest.reset_index().columns.tolist()
+        ] + latest.reset_index().values.tolist()
+        doc = SimpleDocTemplate(
+            output_path,
+            pagesize=landscape(letter),
+            rightMargin=18,
+            leftMargin=18,
+            topMargin=18,
+            bottomMargin=18,
+        )
+        table = Table(rows, repeatRows=1)
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 8),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+                ]
+            )
+        )
+        doc.build([table])
+    else:
+        latest.to_csv(output_path, quoting=csv.QUOTE_MINIMAL, float_format="%.3f")
+
+
+# --------------------------------------------------------------------------- #
+# MAIN                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def run(fmt: str = "csv") -> None:
+    tz_tr = timezone(timedelta(hours=3))
+    stamp = datetime.now(tz_tr).strftime("%Y%m%d_%H%M")
+
+    filetype = fmt if fmt in {"xlsx", "csv", "flatcsv", "pdf", "txt"} else "csv"
+
+    # 1. positions
+    pos = load_ib_positions_ib()  # live connection to IB/TWS
+
+    # --- tidy numeric precision ------------------------------------------------
+    num_cols_pos = ["cost basis", "mark price", "market_value", "unrealized_pnl"]
+    pos[num_cols_pos] = pos[num_cols_pos].round(3)
+    pos = pos.rename(columns={"symbol": "ticker"})
+
+    # 2. technical data
+    tickers = list(MARKET_OVERVIEW.keys()) + pos["ticker"].unique().tolist()
+    ohlc = fetch_ohlc(tickers)
+    tech = compute_indicators(ohlc)
+    tech_last = last_row(tech)[INDICATORS].round(3)
+
+    # 3. macro overview (price & % chg vs yesterday close)
+    macro_px = tech_last[["pct_change"]].copy()
+    macro_px.columns = ["pct_change"]
+    macro_px.insert(0, "close", last_row(tech)["close"].round(3))
+    macro_px.insert(0, "name", [MARKET_OVERVIEW.get(t, t) for t in tech_last.index])
+    macro_px.index.name = "ticker"
+
+    # round & make % column easier to read
+    macro_px["close"] = macro_px["close"].round(3)
+    macro_px["pct_change"] = (macro_px["pct_change"] * 100).round(3)
+
+    # ------------------------------------------------------------------- #
+    # Save results                                                        #
+    # ------------------------------------------------------------------- #
+    out_dir = Path(settings.output_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base = out_dir / f"pre_mkt_{stamp}"
+
+    if filetype == "xlsx":
+        out_file = base.with_suffix(".xlsx")
+        with pd.ExcelWriter(
+            out_file, engine="xlsxwriter", datetime_format="yyyy-mm-dd"
+        ) as xl:
+            pos.to_excel(xl, sheet_name="Holdings", index=False, float_format="%.3f")
+            macro_px.to_excel(
+                xl,
+                sheet_name="Macro",
+                index_label="ticker",
+                float_format="%.3f",
+            )
+            tech_last.to_excel(
+                xl, sheet_name="Tech", index_label="ticker", float_format="%.3f"
+            )
+        print(f"✅ Saved → {out_file}")
+    elif filetype in ("csv", "flatcsv"):
+        base_str = str(base)
+        pos.to_csv(
+            f"{base_str}_holdings.csv",
+            index=False,
+            quoting=csv.QUOTE_MINIMAL,
+            float_format="%.3f",
+        )
+        macro_px.to_csv(
+            f"{base_str}_macro.csv",
+            index_label="ticker",
+            quoting=csv.QUOTE_MINIMAL,
+            float_format="%.3f",
+        )
+        tech_last.to_csv(
+            f"{base_str}_tech.csv",
+            index_label="ticker",
+            quoting=csv.QUOTE_MINIMAL,
+            float_format="%.3f",
+        )
+        print(f"✅ Saved CSVs → {base.parent}")
+    elif filetype == "txt":
+        out_file = base.with_suffix(".txt")
+        with open(out_file, "w") as fh:
+            fh.write("Holdings\n")
+            fh.write(pos.to_string(index=False, float_format=lambda x: f"{x:.3f}"))
+            fh.write("\n\nMacro\n")
+            fh.write(
+                macro_px.reset_index()
+                .rename(columns={"index": "ticker"})
+                .to_string(index=False, float_format=lambda x: f"{x:.3f}")
+            )
+            fh.write("\n\nTech\n")
+            fh.write(
+                tech_last.reset_index()
+                .rename(columns={"index": "ticker"})
+                .to_string(index=False, float_format=lambda x: f"{x:.3f}")
+            )
+        print(f"✅ Saved → {out_file}")
+    elif filetype == "pdf":
+        out_file = base.with_suffix(".pdf")
+        # reportlab 3.x expects a str or file‑like, not a pathlib.Path
+        doc = SimpleDocTemplate(
+            str(out_file),
+            pagesize=landscape(letter),
+            rightMargin=20,
+            leftMargin=20,
+            topMargin=20,
+            bottomMargin=20,
+        )
+        elements = []
+
+        def df_to_table(df):
+            # reportlab's Table object renders text directly, making the PDF text-based and searchable.
+            data = [df.columns.tolist()] + df.values.tolist()
+            table = Table(data)
+            table.setStyle(
+                TableStyle(
+                    [
+                        ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                        ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                        ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                        (
+                            "FONTSIZE",
+                            (0, 0),
+                            (-1, -1),
+                            8,
+                        ),  # Increased font size for better readability
+                        ("BOTTOMPADDING", (0, 0), (-1, 0), 12),
+                        ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+                    ]
+                )
+            )
+            return table
+
+        # tidy column names
+        pos_ren = pos.rename(
+            columns={
+                "cost basis": "CostBasis",
+                "mark price": "MarkPrice",
+                "market_value": "MktValue",
+                "unrealized_pnl": "UnrlzdPnL",
+            }
+        )
+        elements.append(df_to_table(pos_ren))
+        elements.append(Spacer(0, 8))
+        # pretty % column with symbol
+        macro_pdf = macro_px.copy()
+        macro_pdf["pct_change"] = macro_pdf["pct_change"].map(lambda x: f"{x:.3f}%")
+        elements.append(
+            df_to_table(macro_pdf.reset_index().rename(columns={"index": "ticker"}))
+        )
+        elements.append(Spacer(0, 8))
+        elements.append(
+            df_to_table(tech_last.reset_index().rename(columns={"index": "ticker"}))
+        )
+
+        doc.build(elements)
+        print(f"✅ Saved → {out_file}")

--- a/portfolio_exporter/scripts/historic_prices.py
+++ b/portfolio_exporter/scripts/historic_prices.py
@@ -1,0 +1,215 @@
+import os
+import csv
+import argparse
+from portfolio_exporter.core.config import settings
+import pandas as pd
+import yfinance as yf
+
+try:  # optional dependencies
+    import xlsxwriter  # type: ignore
+except Exception:  # pragma: no cover - optional
+    xlsxwriter = None  # type: ignore
+
+try:
+    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib import colors
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+except Exception:  # pragma: no cover - optional
+    SimpleDocTemplate = Table = TableStyle = colors = letter = landscape = None
+
+# optional progress bar
+try:
+    from utils.progress import iter_progress
+
+    PROGRESS = True
+except Exception:  # pragma: no cover - optional
+    PROGRESS = False
+from datetime import datetime
+
+# ---------- IBKR optional integration ----------
+try:
+    from ib_insync import IB, Stock
+
+    IB_AVAILABLE = True
+except ImportError:
+    IB_AVAILABLE = False
+
+IB_HOST, IB_PORT, IB_CID = "127.0.0.1", 7497, 3  # separate clientId for historic pull
+
+EXTRA_TICKERS = ["SPY", "QQQ", "IWM", "^VIX", "DX-Y.NYB"]  # core indices
+PROXY_MAP = {"VIX": "^VIX", "VVIX": "^VVIX", "DXY": "DX-Y.NYB"}
+
+
+def _tickers_from_ib() -> list[str]:
+    """Return unique stock tickers from current IBKR account positions."""
+    if not IB_AVAILABLE:
+        return []
+    ib = IB()
+    try:
+        ib.connect(IB_HOST, IB_PORT, clientId=IB_CID, timeout=3)
+    except Exception:
+        return []
+    positions = ib.positions()
+    ib.disconnect()
+    if not positions:
+        return []
+    # extract underlying symbol for stocks only
+    tickers = {
+        p.contract.symbol.upper() for p in positions if p.contract.secType == "STK"
+    }
+    return sorted(tickers)
+
+
+PORTFOLIO_FILES = ["tickers_live.txt", "tickers.txt"]  # first existing file wins
+
+# Timestamped output (UTC). Includes time so repeated runs don't overwrite.
+DATE_TAG = datetime.utcnow().strftime("%Y%m%d")
+TIME_TAG = datetime.utcnow().strftime("%H%M")
+OUTPUT_DIR = os.path.expanduser(settings.output_dir)
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+OUTPUT_CSV = os.path.join(OUTPUT_DIR, f"historic_prices_{DATE_TAG}_{TIME_TAG}.csv")
+
+
+def load_tickers() -> list[str]:
+    """Return unique tickers prioritising IBKR holdings; otherwise text file."""
+    # 1) try IBKR
+    ib_tickers = _tickers_from_ib()
+    if ib_tickers:
+        mapped_ib = [PROXY_MAP.get(t, t) for t in ib_tickers]
+        return sorted(set(mapped_ib + EXTRA_TICKERS))
+
+    # 2) fallback to file
+    path = next((p for p in PORTFOLIO_FILES if os.path.exists(p)), None)
+    user_tickers = []
+    if path:
+        with open(path) as f:
+            user_tickers = [line.strip().upper() for line in f if line.strip()]
+    mapped = [PROXY_MAP.get(t, t) for t in user_tickers]
+    return sorted(set(mapped + EXTRA_TICKERS))
+
+
+def fetch_and_prepare_data(tickers):
+    """
+    Batch-fetch OHLCV data for tickers over last 60 days with daily interval.
+    Raises ValueError if ticker list is empty.
+    Returns DataFrame with columns:
+    ["date","ticker","open","high","low","close","adj_close","volume"]
+    """
+    if not tickers:
+        raise ValueError("No data fetched for any ticker.")
+    data = yf.download(
+        tickers=tickers,
+        period="60d",
+        interval="1d",
+        group_by="ticker",
+        auto_adjust=False,
+    )
+    columns = ["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"]
+    if data.empty:
+        return pd.DataFrame(columns=columns)
+    dfs = []
+    if isinstance(data.columns, pd.MultiIndex):
+        iterable = iter_progress(tickers, "split") if PROGRESS else tickers
+        for ticker in iterable:
+            if ticker in data:
+                df_t = data[ticker].reset_index()
+                df_t["Ticker"] = ticker
+                dfs.append(df_t)
+    else:
+        df_t = data.reset_index()
+        df_t["Ticker"] = tickers[0]
+        dfs.append(df_t)
+    result = pd.concat(dfs, ignore_index=True)
+    # Rename columns and enforce types
+    result = result.rename(
+        columns={
+            "Date": "date",
+            "Ticker": "ticker",
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Adj Close": "adj_close",
+            "Volume": "volume",
+        }
+    )
+    result["date"] = result["date"].dt.strftime("%Y-%m-%d")
+    result["volume"] = result["volume"].fillna(0).astype(int)
+    return result[columns]
+
+
+def save_to_csv(df: pd.DataFrame):
+    df.to_csv(
+        OUTPUT_CSV,
+        index=False,
+        quoting=csv.QUOTE_MINIMAL,
+        float_format="%.3f",
+    )
+    print(f"✅  Saved {len(df):,} rows → {OUTPUT_CSV}")
+
+
+def save_to_excel(df: pd.DataFrame, path: str) -> None:
+    with pd.ExcelWriter(
+        path, engine="xlsxwriter", datetime_format="yyyy-mm-dd"
+    ) as writer:
+        df.to_excel(
+            writer,
+            sheet_name="Prices",
+            index=False,
+            float_format="%.3f",
+        )
+
+
+def save_to_txt(df: pd.DataFrame, path: str) -> None:
+    with open(path, "w") as fh:
+        fh.write(df.to_string(index=False, float_format=lambda x: f"{x:.3f}"))
+
+
+def save_to_pdf(df: pd.DataFrame, path: str) -> None:
+    # reportlab's Table object renders text directly, making the PDF text-based and searchable.
+    rows_data = [df.columns.tolist()] + df.values.tolist()
+    doc = SimpleDocTemplate(
+        path,
+        pagesize=landscape(letter),
+        rightMargin=18,
+        leftMargin=18,
+        topMargin=18,
+        bottomMargin=18,
+    )
+    table = Table(rows_data, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                (
+                    "FONTSIZE",
+                    (0, 0),
+                    (-1, -1),
+                    8,
+                ),  # Increased font size for better readability
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+            ]
+        )
+    )
+    doc.build([table])
+
+
+def run(fmt: str = "csv") -> None:
+    """Export historical prices using ``fmt`` extension."""
+    tickers = load_tickers()
+    df = fetch_and_prepare_data(tickers)
+    fmt = fmt.lower()
+    if fmt in {"excel", "xlsx"}:
+        path = OUTPUT_CSV.replace(".csv", ".xlsx")
+        save_to_excel(df, path)
+    elif fmt == "pdf":
+        path = OUTPUT_CSV.replace(".csv", ".pdf")
+        save_to_pdf(df, path)
+    elif fmt == "txt":
+        path = OUTPUT_CSV.replace(".csv", ".txt")
+        save_to_txt(df, path)
+    else:
+        save_to_csv(df)

--- a/portfolio_exporter/scripts/net_liq_history_export.py
+++ b/portfolio_exporter/scripts/net_liq_history_export.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+net_liq_history_export.py  –  Export end-of-day Net-Liq / equity curve
+
+• First tries to read Trader Workstation’s auto-saved  dailyNetLiq.csv
+  (TWS ▸ Account Window ▸ Reports ▸ “Export Directory”).
+• If not present – or if you pass  --cp-download  – it pulls the same data
+  from IBKR Client-Portal > PortfolioAnalyst (“Performance – Time Weighted”).
+• Writes a cleaned CSV into the standard iCloud Downloads folder:
+      net_liq_history_<YYYYMMDD-YYYYMMDD_HHMM>.csv
+• With  --plot  it also drops a PNG equity-curve chart beside the CSV.
+
+Usage
+=====
+$ python net_liq_history_export.py                     # auto date-range (all)
+$ python net_liq_history_export.py --start 2024-01-01  # YTD
+$ python net_liq_history_export.py --plot              # + chart
+$ python net_liq_history_export.py --cp-download       # force CP REST fetch
+"""
+
+from __future__ import annotations
+import argparse
+import csv
+import json
+import os
+import sys
+from portfolio_exporter.core.config import settings
+from datetime import datetime, date
+from pathlib import Path
+from typing import Optional
+import io
+
+import pandas as pd  #  pandas ≥1.2
+import requests  #  pip install requests
+
+try:  # optional dependencies
+    import xlsxwriter  # type: ignore
+except Exception:  # pragma: no cover - optional
+    xlsxwriter = None  # type: ignore
+
+try:
+    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib import colors
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+except Exception:  # pragma: no cover - optional
+    SimpleDocTemplate = Table = TableStyle = colors = letter = landscape = None
+
+# ───────────────────────── CONFIG ──────────────────────────
+OUTPUT_DIR = Path(settings.output_dir).expanduser()
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+TIME_TAG = datetime.utcnow().strftime("%H%M")
+
+# ---  1️⃣  where TWS writes dailyNetLiq.csv -----------------
+# If you changed the “Export Directory” in TWS, edit here OR
+# set the env-var  TWS_EXPORT_DIR
+TWS_EXPORT_DIR = Path(os.getenv("TWS_EXPORT_DIR", "~/Jts/Export")).expanduser()
+TWS_NET_LIQ_CSV = TWS_EXPORT_DIR / "dailyNetLiq.csv"
+
+# ---  2️⃣  minimal Client-Portal credentials  ---------------
+# Either export an env-var  CP_REFRESH_TOKEN
+# or edit directly (never commit to git!)
+CP_BASE = "https://localhost:5000/v1/api"  # default CP gateway
+CP_TOKEN = os.getenv("CP_REFRESH_TOKEN", "")  # <your long-lived refresh token>
+VERIFY_SSL = False  # CP’s self-signed cert
+
+
+# ────────────────────── helper functions ───────────────────
+def _parse_dates(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure index is datetime.date, not string."""
+    df.index = pd.to_datetime(df.index).date
+    return df.sort_index()
+
+
+def _read_tws_file() -> Optional[pd.DataFrame]:
+    if not TWS_NET_LIQ_CSV.exists():
+        return None
+    df = pd.read_csv(TWS_NET_LIQ_CSV)
+    if {"Date", "NetLiquidationByCurrency"}.issubset(df.columns):
+        df = (
+            df[["Date", "NetLiquidationByCurrency"]]
+            .rename(columns={"NetLiquidationByCurrency": "net_liq"})
+            .set_index("Date")
+        )
+        return _parse_dates(df)
+    # unexpected format
+    return None
+
+
+def _pa_rest_download() -> pd.DataFrame:
+    """
+    Minimal PortfolioAnalyst /rest API call.
+    Docs: https://interactivebrokers.github.io/cpwebapi/pa.html
+    """
+    if not CP_TOKEN:
+        sys.exit("❌  Set CP_REFRESH_TOKEN env-var or edit CP_TOKEN in script.")
+
+    session = requests.Session()
+    session.verify = VERIFY_SSL
+
+    # 1) refresh -> gateway’s time-limited bearer token
+    r = session.post(f"{CP_BASE}/iserver/reauthorize", json={"refreshtoken": CP_TOKEN})
+    r.raise_for_status()
+
+    # 2) request the PA CSV
+    params = {"acctIds": "", "fromDate": "", "toDate": "", "format": "CSV"}
+    r = session.get(f"{CP_BASE}/pa/performance/timeweighted", params=params)
+    r.raise_for_status()
+
+    # CSV arrives as text
+    df_all = pd.read_csv(io.StringIO(r.text))
+    if {"Date", "NetLiquidation"}.issubset(df_all.columns):
+        df = (
+            df_all[["Date", "NetLiquidation"]]
+            .rename(columns={"NetLiquidation": "net_liq"})
+            .set_index("Date")
+        )
+        return _parse_dates(df)
+    sys.exit("❌  Unexpected column layout from PortfolioAnalyst CSV.")
+
+
+def _filter_range(df: pd.DataFrame, start: str | None, end: str | None) -> pd.DataFrame:
+    if start:
+        df = df[df.index >= datetime.fromisoformat(start).date()]
+    if end:
+        df = df[df.index <= datetime.fromisoformat(end).date()]
+    return df
+
+
+def _save_csv(df: pd.DataFrame, start_label: str, end_label: str) -> Path:
+    out_name = f"net_liq_history_{start_label}-{end_label}_{TIME_TAG}.csv"
+    out_path = OUTPUT_DIR / out_name
+    df.to_csv(
+        out_path, index_label="date", quoting=csv.QUOTE_MINIMAL, float_format="%.3f"
+    )
+    return out_path
+
+
+def _save_excel(df: pd.DataFrame, start_label: str, end_label: str) -> Path:
+    out_name = f"net_liq_history_{start_label}-{end_label}_{TIME_TAG}.xlsx"
+    out_path = OUTPUT_DIR / out_name
+    with pd.ExcelWriter(
+        out_path, engine="xlsxwriter", datetime_format="yyyy-mm-dd"
+    ) as writer:
+        df.to_excel(
+            writer, sheet_name="NetLiq", index_label="date", float_format="%.3f"
+        )
+    return out_path
+
+
+def _save_pdf(df: pd.DataFrame, start_label: str, end_label: str) -> Path:
+    # reportlab's Table object renders text directly, making the PDF text-based and searchable.
+    out_name = f"net_liq_history_{start_label}-{end_label}_{TIME_TAG}.pdf"
+    out_path = OUTPUT_DIR / out_name
+    df_reset = df.reset_index()
+    rows_data = [df_reset.columns.tolist()] + df_reset.values.tolist()
+    doc = SimpleDocTemplate(
+        out_path,
+        pagesize=landscape(letter),
+        rightMargin=18,
+        leftMargin=18,
+        topMargin=18,
+        bottomMargin=18,
+    )
+    table = Table(rows_data, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                (
+                    "FONTSIZE",
+                    (0, 0),
+                    (-1, -1),
+                    10,
+                ),  # Increased font size for better readability
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+            ]
+        )
+    )
+    doc.build([table])
+    return out_path
+
+
+def _save_txt(df: pd.DataFrame, start_label: str, end_label: str) -> Path:
+    out_name = f"net_liq_history_{start_label}-{end_label}_{TIME_TAG}.txt"
+    out_path = OUTPUT_DIR / out_name
+    with open(out_path, "w") as fh:
+        fh.write(df.to_string(index=True, float_format=lambda x: f"{x:.3f}"))
+    return out_path
+
+
+def _plot(df: pd.DataFrame, out_csv: Path):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("⚠️  matplotlib not installed – skipping chart.")
+        return
+    fig, ax = plt.subplots()
+    ax.plot(df.index, df["net_liq"])
+    ax.set_title("Equity Curve (Net Liquidation)")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Net-Liq, USD")
+    fig.autofmt_xdate()
+    png_path = out_csv.with_suffix(".png")
+    fig.savefig(png_path, dpi=110, bbox_inches="tight")
+    print(f"📈  Saved chart → {png_path}")
+
+
+# ─────────────────────────── MAIN ──────────────────────────
+def run(fmt: str = "csv") -> None:
+    filetype = fmt.lower()
+    args = argparse.Namespace(
+        start=None,
+        end=None,
+        plot=False,
+        cp_download=False,
+        excel=filetype in {"excel", "xlsx"},
+        pdf=filetype == "pdf",
+        txt=filetype == "txt",
+    )
+
+    # 1) pick data source
+    df: Optional[pd.DataFrame] = None
+    if not args.cp_download:
+        df = _read_tws_file()
+        if df is not None:
+            print(f"✅  Loaded {len(df):,} rows from dailyNetLiq.csv")
+    if df is None:
+        print("ℹ️  Pulling data from Client-Portal PortfolioAnalyst …")
+        df = _pa_rest_download()
+
+    # 2) optional date-range slice
+    df = _filter_range(df, args.start, args.end)
+    if df.empty:
+        sys.exit("❌  No data in the selected date range.")
+
+    start_lbl = df.index.min().strftime("%Y%m%d")
+    end_lbl = df.index.max().strftime("%Y%m%d")
+
+    if args.excel:
+        out_path = _save_excel(df, start_lbl, end_lbl)
+        print(f"💾  Saved Excel workbook → {out_path}")
+    elif args.pdf:
+        out_path = _save_pdf(df, start_lbl, end_lbl)
+        print(f"💾  Saved PDF report   → {out_path}")
+    elif args.txt:
+        out_path = _save_txt(df, start_lbl, end_lbl)
+        print(f"💾  Saved text report  → {out_path}")
+    else:
+        out_path = _save_csv(df, start_lbl, end_lbl)
+        print(f"💾  Saved {len(df):,} rows → {out_path}")
+
+    if args.plot:
+        _plot(df, out_path if isinstance(out_path, Path) else Path(out_path))

--- a/portfolio_exporter/scripts/option_chain_snapshot.py
+++ b/portfolio_exporter/scripts/option_chain_snapshot.py
@@ -1,0 +1,797 @@
+#!/usr/bin/env python3
+"""
+option_chain_snapshot.py  –  Export a full option-chain snapshot for one or more symbols
+
+• Uses IBKR market-data (ib_insync) and writes CSVs to your iCloud Downloads dir.
+• Handles live, frozen, delayed-streaming *or* delayed-snapshot data automatically.
+• If Greeks / IV or bid/ask are still missing after streaming, it takes a one-shot
+  delayed snapshot for each affected contract to fill the gaps.
+
+Usage
+=====
+# snapshot every underlying currently held in the IB account
+$ python option_chain_snapshot.py
+
+# snapshot only MSFT and QQQ
+$ python option_chain_snapshot.py --symbols MSFT,QQQ
+
+# snapshot TSLA for two expiries and AAPL for one
+$ python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:20250620'
+"""
+
+import argparse
+import csv
+import logging
+import math
+from typing import Any
+import os
+import time
+from portfolio_exporter.core.config import settings
+from datetime import datetime, timezone, date
+from typing import List, Sequence
+import zipfile
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+from ib_insync import IB, Option, Stock
+from utils.bs import bs_greeks
+
+try:  # optional dependencies
+    import xlsxwriter  # type: ignore
+except Exception:  # pragma: no cover - optional
+    xlsxwriter = None  # type: ignore
+
+try:
+    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib import colors
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+except Exception:  # pragma: no cover - optional
+    SimpleDocTemplate = Table = TableStyle = colors = letter = landscape = None
+
+from bisect import bisect_left
+
+
+# ── helper: get reliable split‑adjusted spot ──
+def _safe_spot(ib: IB, stk: Stock, streaming_tk):
+    """
+    Return a trustworthy spot:
+      • live/frozen bid/ask or last if available
+      • else previous regular‑session close (split‑adjusted).
+    """
+    spot_val = streaming_tk.marketPrice() or streaming_tk.last
+    if spot_val and spot_val > 0:
+        return spot_val
+    # pull adjusted close (1‑day bar, regular trading hours)
+    bars = ib.reqHistoricalData(
+        stk,
+        endDateTime="",
+        durationStr="1 D",
+        barSizeSetting="1 day",
+        whatToShow="TRADES",
+        useRTH=True,
+        formatDate=1,
+    )
+    return bars[-1].close if bars else np.nan
+
+
+# ─────────── contract resolution helper ───────────
+def _resolve_contract(ib: IB, template: Option):
+    """
+    Return a fully‑qualified Contract for the given template, handling
+    ambiguous matches via `ib.qualifyContracts` first (fast‑path) and
+    falling back to `reqContractDetails` only if qualification fails.
+
+    Preference order for ambiguous matches:
+      1. tradingClass equal to the underlying symbol
+      2. first contract returned by IB
+
+    Returns None if no contract can be qualified.
+    """
+    # --- fast path: qualifyContracts ----------------------------------------------------
+    try:
+        ql = ib.qualifyContracts(template)
+        if ql:
+            # If there is only one qualified contract, use it immediately
+            if len(ql) == 1:
+                return ql[0]
+            # More than one – pick by tradingClass heuristics
+            for c in ql:
+                if c.tradingClass == template.symbol:
+                    return c
+            return ql[0]
+    except Exception:
+        # qualification can raise when template is too fuzzy – fall through
+        pass
+
+    # --- slow path: reqContractDetails --------------------------------------------------
+    cds = ib.reqContractDetails(template)
+    if not cds:
+        return None
+    if len(cds) == 1:
+        return cds[0].contract
+    for cd in cds:
+        if cd.contract.tradingClass == template.symbol:
+            return cd.contract
+    return cds[0].contract
+
+
+# ───────────────────────── CONFIG ──────────────────────────
+OUTPUT_DIR = os.path.expanduser(settings.output_dir)
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+PORTFOLIO_FILES = ["tickers_live.txt", "tickers.txt"]
+
+IB_HOST, IB_PORT, IB_CID = "127.0.0.1", 7497, 10
+LOG_FMT = "%(asctime)s %(levelname)s %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOG_FMT)
+
+logger = logging.getLogger(__name__)
+# silence routine IBKR chatter – only show CRITICAL
+for _n in ("ib_insync", "ib_insync.ib", "ib_insync.wrapper"):
+    logging.getLogger(_n).setLevel(logging.CRITICAL)
+
+# optional progress bar
+try:
+    from utils.progress import iter_progress
+
+    PROGRESS = True
+except Exception:  # pragma: no cover - optional
+    PROGRESS = False
+
+# ---------------------------------------------------------------------------
+
+
+def create_zip(files: List[str], dest: str) -> None:
+    """Create a zip archive containing the given files."""
+    with zipfile.ZipFile(dest, "w") as zf:
+        for path in files:
+            zf.write(path, os.path.basename(path))
+
+
+def cleanup(files: List[str]) -> None:
+    """Delete the given files, ignoring missing paths."""
+    for path in files:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def load_tickers_from_files() -> List[str]:
+    """Read tickers from the first portfolio file that exists."""
+    path = next((p for p in PORTFOLIO_FILES if os.path.exists(p)), None)
+    if not path:
+        return []
+    with open(path) as fh:
+        return [ln.strip().upper() for ln in fh if ln.strip()]
+
+
+def get_portfolio_tickers(ib: IB) -> List[str]:
+    """Return all stock / ETF symbols currently held in the account."""
+    tickers: set[str] = {
+        pos.contract.symbol.upper()
+        for pos in ib.portfolio()
+        if pos.contract.secType == "STK"
+    }
+    return sorted(tickers)
+
+
+# ────────────── expiry helpers ──────────────
+def choose_expiry(expirations: Sequence[str]) -> str:
+    """Pick weekly ≤ 7 days, else first Friday, else earliest."""
+    today = datetime.utcnow().date()
+    # within a week
+    for e in expirations:
+        if (datetime.strptime(e, "%Y%m%d").date() - today).days <= 7:
+            return e
+    # first Friday
+    for e in expirations:
+        if datetime.strptime(e, "%Y%m%d").weekday() == 4:
+            return e
+    return expirations[0]
+
+
+def pick_expiry_with_hint(expirations: Sequence[str], hint: str | None) -> str:
+    """
+    Smart expiry picker that honours a user *hint*.
+
+    Supported hint formats:
+    • exact ``YYYYMMDD`` → use if available
+    • ``YYYYMM`` prefix → choose 3rd Friday of that month, else first expiry
+    • month name/abbr (``july``) → same logic across any year
+    • ``day month`` (``26 jun``/``jun 26``/``26/06``) → nearest expiry on or
+      after that date
+    • otherwise falls back to :func:`choose_expiry`.
+    """
+    if not expirations:
+        raise ValueError("Expirations list cannot be empty.")
+    expirations = sorted(expirations)
+
+    if not hint:
+        return choose_expiry(expirations)
+
+    hint = hint.strip().lower()
+    if not hint:
+        return choose_expiry(expirations)
+
+    # exact date
+    if len(hint) == 8 and hint.isdigit() and hint in expirations:
+        return hint
+
+    # helper
+    def third_friday(yyyymmdd: str) -> bool:
+        dt = datetime.strptime(yyyymmdd, "%Y%m%d")
+        return dt.weekday() == 4 and 15 <= dt.day <= 21
+
+    # YYYYMM prefix
+    if len(hint) == 6 and hint.isdigit():
+        m = [e for e in expirations if e.startswith(hint)]
+        if m:
+            fridays = [e for e in m if third_friday(e)]
+            return fridays[0] if fridays else m[0]
+
+    # month name / abbr
+    # day + month input
+    def parse_day_month(h: str) -> tuple[int, int] | tuple[None, None]:
+        fmts = ["%d %b", "%d %B", "%b %d", "%B %d", "%d/%m", "%d-%m", "%d.%m"]
+        for fmt in fmts:
+            try:
+                dt = datetime.strptime(h, fmt)
+                return dt.day, dt.month
+            except ValueError:
+                continue
+        return None, None
+
+    day, month = parse_day_month(hint)
+    if day:
+        first_year = datetime.strptime(expirations[0], "%Y%m%d").year
+        candidate = date(first_year, month, day)
+        for e in expirations:
+            ed = datetime.strptime(e, "%Y%m%d").date()
+            if ed >= candidate:
+                return e
+        candidate = date(first_year + 1, month, day)
+        for e in expirations:
+            ed = datetime.strptime(e, "%Y%m%d").date()
+            if ed >= candidate:
+                return e
+
+    try:
+        month_idx = datetime.strptime(hint[:3], "%b").month
+    except ValueError:
+        month_idx = None
+    if month_idx:
+        same_month = [e for e in expirations if int(e[4:6]) == month_idx]
+        if same_month:
+            fridays = [e for e in same_month if third_friday(e)]
+            return fridays[0] if fridays else same_month[0]
+
+    return choose_expiry(expirations)
+
+
+# ──────── per-symbol expiry map parser ────────
+def parse_symbol_expiries(spec: str) -> dict[str, list[str]]:
+    """Parse 'TSLA:20250620,20250703;AAPL:20250620' style strings."""
+    mapping: dict[str, list[str]] = {}
+    for part in spec.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        if ":" in part:
+            sym, exp_str = part.split(":", 1)
+            expiries = [e.strip() for e in exp_str.split(",") if e.strip()]
+        else:
+            sym, expiries = part, []
+        sym = sym.strip().upper()
+        if not sym:
+            continue
+        mapping.setdefault(sym, []).extend(expiries)
+    return mapping
+
+
+def prompt_symbol_expiries() -> dict[str, list[str]]:
+    """Interactively build a symbol→expiry map."""
+    result: dict[str, list[str]] = {}
+    while True:
+        symbol = input("Symbol (blank to finish): ").strip()
+        if not symbol:
+            break
+        symbol = symbol.upper()
+        exp = input(
+            f"Expiries for {symbol} (comma-separated, blank for auto): "
+        ).strip()
+        entry = parse_symbol_expiries(f"{symbol}:{exp}" if exp else symbol)
+        for sym, vals in entry.items():
+            result.setdefault(sym, []).extend(vals)
+    return result
+
+
+# ─────────── Black–Scholes fallback (for delayed feeds) ───────────
+
+
+# ─────────── snapshot helpers ───────────
+def _g(tk, field):
+    """Return greek/IV attribute if present – else NaN."""
+    if hasattr(tk, field):
+        val = getattr(tk, field)
+        if val not in (None, -1):
+            return val
+    mg = getattr(tk, "modelGreeks", None)
+    if mg:
+        val = getattr(mg, field, np.nan)
+        if val not in (None, -1):
+            return val
+    return np.nan
+
+
+def _attr(tk, field):
+    """Return a numeric ticker attribute or NaN if unavailable."""
+    val = getattr(tk, field, np.nan)
+    return np.nan if val in (None, -1) else val
+
+
+# ── helper: robust open‑interest getter ──
+
+
+def fetch_yf_open_interest(symbol: str, expiry: str) -> dict[tuple[float, str], int]:
+    """
+    Return {(strike, right): open_interest} for a given symbol‑expiry pair
+    using yfinance.
+
+    yfinance expects the expiry in 'YYYY‑MM‑DD' format, whereas IB returns
+    'YYYYMMDD'.  We normalise the string first, then attempt to fetch.
+    Falls back to {} on any error or if the dataframe is empty.
+    """
+    # normalise expiry to YYYY‑MM‑DD for yfinance
+    if len(expiry) == 8 and expiry.isdigit():
+        expiry_fmt = f"{expiry[:4]}-{expiry[4:6]}-{expiry[6:]}"
+    else:
+        expiry_fmt = expiry
+
+    try:
+        oc = yf.Ticker(symbol).option_chain(expiry_fmt)
+    except Exception as e:  # pragma: no cover – network failures
+        logger.debug("yfinance OI fetch fail %s %s: %s", symbol, expiry_fmt, e)
+        return {}
+
+    mapping: dict[tuple[float, str], int] = {}
+    for right, df in (("C", oc.calls), ("P", oc.puts)):
+        if getattr(df, "empty", True):
+            continue
+        for _, row in df[["strike", "openInterest"]].dropna().iterrows():
+            try:
+                mapping[(float(row["strike"]), right)] = int(row["openInterest"])
+            except Exception:
+                continue
+    return mapping
+
+
+def _wait_for_snapshots(ib: IB, snaps: list[tuple], timeout=8.0):
+    """Wait until all tickers have a non-None timestamp or timeout."""
+    end = time.time() + timeout
+    while time.time() < end:
+        if all(getattr(tk, "time", None) for _, tk in snaps):
+            break
+        time.sleep(0.25)
+
+
+def _wait_attr(tk, field: str, timeout: float = 2.0) -> None:
+    """Poll ticker until attribute present or timeout."""
+    end = time.time() + timeout
+    while time.time() < end:
+        val = getattr(tk, field, None)
+        if val not in (None, -1):
+            break
+        time.sleep(0.25)
+
+
+# ─────────── core chain routine ───────────
+def snapshot_chain(ib: IB, symbol: str, expiry_hint: str | None = None) -> pd.DataFrame:
+    logger.info("Snapshot %s", symbol)
+
+    stk = Stock(symbol, "SMART", "USD")
+    ib.qualifyContracts(stk)
+    if not stk.conId:
+        raise RuntimeError(f"Unable to qualify underlying {symbol}")
+
+    chains = ib.reqSecDefOptParams(symbol, "", "STK", stk.conId)
+    if not chains:
+        raise RuntimeError("No option-chain data")
+
+    # choose the chain with the richest strike list (the “real” OPRA feed),
+    # fall back to the first one if all are empty
+    chain = max(
+        (c for c in chains if c.strikes),
+        key=lambda c: len(c.strikes),
+        default=chains[0],
+    )
+    logger.info(
+        "Using chain %s (exchange=%s, strikes=%d, expiries=%d)",
+        getattr(chain, "tradingClass", "<n/a>"),
+        getattr(chain, "exchange", "<n/a>"),
+        len(chain.strikes),
+        len(chain.expirations),
+    )
+    expiry = pick_expiry_with_hint(sorted(chain.expirations), expiry_hint)
+
+    # always fetch open interest from Yahoo Finance
+    yf_open_interest = fetch_yf_open_interest(symbol, expiry)
+
+    # trading class
+    root_tc = (
+        chain.tradingClasses[0]
+        if getattr(chain, "tradingClasses", None)
+        else getattr(chain, "tradingClass", symbol) or symbol
+    )
+    use_trading_class = bool(root_tc and root_tc != symbol)
+
+    # ── spot price and ±20 strikes ────────────────────────────────
+    strikes_all = sorted(chain.strikes)
+
+    spot_tk = ib.reqMktData(stk, "", True, False)
+    ib.sleep(0.5)
+
+    spot = _safe_spot(ib, stk, spot_tk)
+
+    if spot_tk.contract:
+        ib.cancelMktData(spot_tk.contract)
+
+    if np.isnan(spot):
+        logger.warning("Could not obtain reliable spot price – using full strike list")
+        strikes = strikes_all
+    else:
+        # if spot lies outside the strike lattice (e.g. right after a split) warn & keep full list
+        if spot < strikes_all[0] or spot > strikes_all[-1]:
+            logger.warning(
+                "Spot %.2f is outside strike range %s‑%s (possible recent split); using full strike list.",
+                spot,
+                strikes_all[0],
+                strikes_all[-1],
+            )
+            strikes = strikes_all
+        else:
+            idx = bisect_left(strikes_all, spot)
+            start = max(0, idx - 20)
+            end = min(len(strikes_all), idx + 21)
+            strikes = strikes_all[start:end]
+            logger.info(
+                "Spot %.2f → selected %d strikes (%s‑%s)",
+                spot,
+                len(strikes),
+                strikes[0],
+                strikes[-1],
+            )
+
+    # ── build contracts and resolve ambiguities ──
+    raw_templates = [
+        Option(
+            symbol,
+            expiry,
+            strike,
+            right,
+            exchange="SMART",
+            currency="USD",
+            tradingClass=root_tc,  # <‑‑ add this
+        )
+        for strike in strikes
+        for right in ("C", "P")
+    ]
+
+    contracts: list[Option] = []
+    for tmpl in raw_templates:
+        # --- first try with tradingClass as provided (root_tc) -----------------
+        c = _resolve_contract(ib, tmpl)
+
+        # --- fallback #1: strip tradingClass if first attempt failed -----------
+        if c is None and use_trading_class:
+            tmpl_no_tc = Option(
+                tmpl.symbol,
+                tmpl.lastTradeDateOrContractMonth,
+                tmpl.strike,
+                tmpl.right,
+                exchange=tmpl.exchange,
+                currency=tmpl.currency,
+            )
+            c = _resolve_contract(ib, tmpl_no_tc)
+
+        # --- fallback #2: use the underlying symbol as tradingClass ------------
+        if c is None and use_trading_class and root_tc != symbol:
+            tmpl_sym_tc = Option(
+                tmpl.symbol,
+                tmpl.lastTradeDateOrContractMonth,
+                tmpl.strike,
+                tmpl.right,
+                exchange=tmpl.exchange,
+                currency=tmpl.currency,
+                tradingClass=symbol,  # use the underlying itself
+            )
+            c = _resolve_contract(ib, tmpl_sym_tc)
+
+        if c:
+            contracts.append(c)
+
+    if not contracts:
+        raise RuntimeError(
+            "No option contracts qualified for the chosen strikes / expiry"
+        )
+
+    # stream market data (need streaming for generic-tick 101)
+    snapshots = [
+        (
+            c,
+            ib.reqMktData(
+                c,
+                "",  # let IB decide tick types; avoids eid errors
+                snapshot=False,
+                regulatorySnapshot=False,
+            ),
+        )
+        for c in contracts
+    ]
+    _wait_for_snapshots(ib, snapshots)
+
+    # cancel streams
+    for _, snap in snapshots:
+        ib.cancelMktData(snap.contract)
+
+    # ── one-shot snapshot fallback for missing price/IV ──
+    for con, tk in snapshots:
+        price_missing = (tk.bid in (None, -1)) and (tk.last in (None, -1))
+        iv_missing = math.isnan(_g(tk, "impliedVolatility"))
+        if price_missing or iv_missing:
+            snap = ib.reqMktData(
+                con, "", True, False
+            )  # snapshot: genericTickList must be empty
+            ib.sleep(0.35)
+            for fld in ("bid", "ask", "last", "close", "impliedVolatility"):
+                val = getattr(snap, fld, None)
+                if val not in (None, -1):
+                    setattr(tk, fld, val)
+            if getattr(snap, "modelGreeks", None):
+                tk.modelGreeks = snap.modelGreeks
+            # Copy volume if present
+            if getattr(snap, "volume", None) not in (None, -1):
+                tk.volume = snap.volume
+            if snap.contract:
+                ib.cancelMktData(snap.contract)
+
+    # build rows
+    ts_local = datetime.now(ZoneInfo("Europe/Istanbul"))
+    ts = ts_local.isoformat()
+    rows = []
+    for con, tk in snapshots:
+        oi_attr = "callOpenInterest" if con.right == "C" else "putOpenInterest"
+        iv_val = _g(tk, "impliedVolatility")
+        delta_val = _g(tk, "delta")
+        gamma_val = _g(tk, "gamma")
+        vega_val = _g(tk, "vega")
+        theta_val = _g(tk, "theta")
+
+        # Black-Scholes fallback if still NaN
+        if any(np.isnan(x) for x in (delta_val, gamma_val, vega_val, theta_val)):
+            if spot and iv_val and not np.isnan(iv_val):
+                exp_dt = datetime.strptime(expiry, "%Y%m%d").replace(
+                    tzinfo=timezone.utc
+                )
+                T = max(
+                    (exp_dt - datetime.now(timezone.utc)).total_seconds()
+                    / (365 * 24 * 3600),
+                    1 / (365 * 24),
+                )
+                bs = bs_greeks(spot, con.strike, T, 0.01, iv_val, con.right == "C")
+                delta_val = bs["delta"] if np.isnan(delta_val) else delta_val
+                gamma_val = bs["gamma"] if np.isnan(gamma_val) else gamma_val
+                vega_val = bs["vega"] if np.isnan(vega_val) else vega_val
+                theta_val = bs["theta"] if np.isnan(theta_val) else theta_val
+
+        mid_price = np.nan if any(np.isnan([tk.bid, tk.ask])) else (tk.bid + tk.ask) / 2
+
+        rows.append(
+            {
+                "timestamp": ts,
+                "symbol": symbol,
+                "spot": spot,
+                "expiry": expiry,
+                "strike": con.strike,
+                "right": con.right,
+                "bid": tk.bid if tk.bid not in (None, -1) else np.nan,
+                "ask": tk.ask if tk.ask not in (None, -1) else np.nan,
+                "mid_price": mid_price,
+                "iv": iv_val,
+                "delta": delta_val,
+                "gamma": gamma_val,
+                "vega": vega_val,
+                "theta": theta_val,
+                "open_interest": yf_open_interest.get((con.strike, con.right), np.nan),
+                "volume": _attr(tk, "volume"),
+            }
+        )
+
+    df = (
+        pd.DataFrame(rows).sort_values(["right", "strike"]).reset_index(drop=True)
+        if rows
+        else pd.DataFrame()
+    )
+
+    return df
+
+
+def _save_excel(df: pd.DataFrame, path: str) -> None:
+    with pd.ExcelWriter(
+        path, engine="xlsxwriter", datetime_format="yyyy-mm-dd"
+    ) as writer:
+        df.to_excel(writer, sheet_name="Options", index=False, float_format="%.3f")
+
+
+def _save_pdf(df: pd.DataFrame, path: str) -> None:
+    # reportlab's Table object renders text directly, making the PDF text-based and searchable.
+    rows_data = [df.columns.tolist()] + df.values.tolist()
+    doc = SimpleDocTemplate(
+        path,
+        pagesize=landscape(letter),
+        rightMargin=18,
+        leftMargin=18,
+        topMargin=18,
+        bottomMargin=18,
+    )
+    table = Table(rows_data, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                (
+                    "FONTSIZE",
+                    (0, 0),
+                    (-1, -1),
+                    8,
+                ),  # Increased font size for better readability
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+            ]
+        )
+    )
+    doc.build([table])
+
+
+def _save_txt(df: pd.DataFrame, path: str) -> None:
+    with open(path, "w") as fh:
+        fh.write(df.to_string(index=False, float_format=lambda x: f"{x:.3f}"))
+
+
+# ─────────────────────────── MAIN ──────────────────────────
+def run(fmt: str = "csv") -> None:
+    filetype = fmt.lower()
+    args = argparse.Namespace(
+        symbols=None,
+        symbol_expiries=None,
+        excel=filetype in {"excel", "xlsx"},
+        pdf=filetype == "pdf",
+        txt=filetype == "txt",
+    )
+
+    ib = IB()
+    try:
+        ib.connect(IB_HOST, IB_PORT, IB_CID, timeout=10)
+
+        # try live → frozen → delayed-streaming → delayed snapshot
+        for _md_type in (1, 2, 3, 4):
+            try:
+                ib.reqMarketDataType(_md_type)
+                break
+            except Exception:
+                continue
+    except Exception as exc:
+        logger.error("IBKR connection failed: %s", exc)
+        return
+
+    # decide symbols / expiries
+    interactive = False
+    if args.symbol_expiries:
+        se_map = parse_symbol_expiries(args.symbol_expiries)
+        symbols = list(se_map)
+        interactive = False
+    elif args.symbols:
+        symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+        se_map = {s: [] for s in symbols}
+        interactive = False
+    else:
+        se_map = prompt_symbol_expiries()
+        interactive = True
+        if se_map:
+            symbols = list(se_map)
+        else:
+            symbols = get_portfolio_tickers(ib) or load_tickers_from_files()
+            se_map = {s: [] for s in symbols}
+
+    if not symbols:
+        logger.error("No symbols to process — aborting.")
+        ib.disconnect()
+        return
+
+    portfolio_mode = not args.symbols and not args.symbol_expiries and not se_map
+    expiry_hint = None
+    if not portfolio_mode and not args.symbol_expiries and not interactive:
+        hint = input(
+            "Desired expiry (YYYYMMDD / YYYYMM / month name / day month), leave empty for auto: "
+        ).strip()
+        expiry_hint = hint or None
+
+    logger.info("Symbols: %s", ", ".join(symbols))
+    iterable = iter_progress(symbols, "Option snapshots") if PROGRESS else symbols
+
+    date_tag = datetime.now(ZoneInfo("Europe/Istanbul")).strftime("%Y%m%d_%H%M")
+    combined: list[pd.DataFrame] = []
+    created_files: list[str] = []
+    for sym in iterable:
+        hints = se_map.get(sym, [expiry_hint])
+        hints = hints or [expiry_hint]
+        for hint in hints:
+            try:
+                df = snapshot_chain(ib, sym, hint)
+                if df.empty:
+                    logger.warning("%s %s – no data", sym, hint)
+                    continue
+                if portfolio_mode:
+                    combined.append(df)
+                else:
+                    label = hint if hint else "auto"
+                    out_base = os.path.join(
+                        OUTPUT_DIR, f"option_chain_{sym}_{label}_{date_tag}"
+                    )
+                    if args.excel:
+                        path = f"{out_base}.xlsx"
+                        _save_excel(df, path)
+                    elif args.pdf:
+                        path = f"{out_base}.pdf"
+                        _save_pdf(df, path)
+                    elif args.txt:
+                        path = f"{out_base}.txt"
+                        _save_txt(df, path)
+                    else:
+                        path = f"{out_base}.csv"
+                        df.to_csv(
+                            path,
+                            index=False,
+                            quoting=csv.QUOTE_MINIMAL,
+                            float_format="%.3f",
+                        )
+                    created_files.append(path)
+                    logger.info("Saved %s (%d rows)", path, len(df))
+            except Exception as e:
+                logger.warning("%s %s – skipped: %s", sym, hint, e)
+
+    if portfolio_mode and combined:
+        df_all = pd.concat(combined, ignore_index=True)
+        out_base = os.path.join(OUTPUT_DIR, f"option_chain_portfolio_{date_tag}")
+        if args.excel:
+            out_path = f"{out_base}.xlsx"
+            _save_excel(df_all, out_path)
+        elif args.pdf:
+            out_path = f"{out_base}.pdf"
+            _save_pdf(df_all, out_path)
+        elif args.txt:
+            out_path = f"{out_base}.txt"
+            _save_txt(df_all, out_path)
+        else:
+            out_path = f"{out_base}.csv"
+            df_all.to_csv(
+                out_path, index=False, quoting=csv.QUOTE_MINIMAL, float_format="%.3f"
+            )
+        logger.info(
+            "Saved consolidated portfolio snapshot → %s (%d rows)",
+            out_path,
+            len(df_all),
+        )
+        created_files.append(out_path)
+
+    if created_files:
+        zip_path = os.path.join(OUTPUT_DIR, f"option_chain_{date_tag}.zip")
+        create_zip(created_files, zip_path)
+        cleanup(created_files)
+        logger.info("Created %s", zip_path)
+
+    ib.disconnect()

--- a/portfolio_exporter/scripts/orchestrate_dataset.py
+++ b/portfolio_exporter/scripts/orchestrate_dataset.py
@@ -1,0 +1,143 @@
+import io
+import os
+import subprocess
+import sys
+import zipfile
+from portfolio_exporter.core.config import settings
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import List, Tuple
+
+from fpdf import FPDF
+from pypdf import PdfWriter
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from rich.console import Console
+
+# Directory where orchestrated dataset and script outputs are stored.
+OUTPUT_DIR = os.path.expanduser(settings.output_dir)
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def run_script(cmd: list[str]) -> List[str]:
+    """Run a script and return the newly created files in OUTPUT_DIR."""
+    out_dir = OUTPUT_DIR
+    before = set(os.listdir(out_dir))
+    env = os.environ.copy()
+    env["OUTPUT_DIR"] = out_dir
+    subprocess.run(
+        [sys.executable, *cmd],
+        check=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=600,  # fail fast if a script hangs >10 min
+        env=env,
+    )
+    after = set(os.listdir(out_dir))
+    new = after - before
+    return [os.path.join(out_dir, f) for f in new]
+
+
+def merge_pdfs(files_by_script: List[Tuple[str, List[str]]], dest: str) -> None:
+    """Merge the given PDF files into a single output, adding bookmarks for each script and title pages, skipping non-PDF files."""
+    merger = PdfWriter()
+    for title, files in files_by_script:
+        pdfs = [path for path in files if path.lower().endswith(".pdf")]
+        if not pdfs:
+            continue
+
+        clean_title = title.replace("_", " ").replace(".py", "").title()
+
+        # Create a title page using FPDF
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", "B", 24)
+        pdf.cell(0, 100, clean_title, 0, 1, "C")
+
+        # Save the title page to a BytesIO object
+        title_page_pdf = io.BytesIO(pdf.output(dest="S").encode("latin-1"))
+        merger.append(title_page_pdf)
+
+        # Add bookmark for the title page
+        merger.add_outline_item(clean_title, len(merger.pages) - 1)
+
+        for path in pdfs:
+            merger.append(path)
+    merger.write(dest)
+    merger.close()
+
+
+def create_zip(files: List[str], dest: str) -> None:
+    """Create a zip archive containing the given files."""
+    with zipfile.ZipFile(dest, "w") as zf:
+        for path in files:
+            zf.write(path, os.path.basename(path))
+
+
+def cleanup(files: List[str]) -> None:
+    """Delete the given files, ignoring missing paths."""
+    for path in files:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def run(fmt: str = "csv") -> None:
+    fmt = fmt.lower()
+
+    scripts = [
+        ["historic_prices.py"],
+        ["portfolio_greeks.py"],
+        ["live_feed.py"],
+        ["daily_pulse.py"],
+    ]
+    # Add format flag if not default
+    if fmt == "pdf":
+        scripts[0].append("--pdf")
+        scripts[1].append("--pdf")
+        scripts[2].append("--pdf")
+    scripts[3].extend(["--filetype", fmt])
+
+    files_by_script: List[Tuple[str, List[str]]] = []
+    console = Console(
+        force_terminal=True
+    )  # force Rich to treat IDE/CI output as a real TTY
+    progress = Progress(
+        BarColumn(),
+        TextColumn("{task.percentage:>3.0f}%"),
+        TextColumn("{task.description}"),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+        transient=True,
+        auto_refresh=False,  # no automatic animation
+    )
+    with progress:
+        overall = progress.add_task("overall", total=len(scripts))
+        for cmd in scripts:
+            task = progress.add_task(cmd[0], total=1)
+            new_files = run_script(cmd)
+            if new_files:
+                files_by_script.append((cmd[0], new_files))
+            progress.update(task, completed=1)  # instantly fill bar
+            progress.advance(overall)
+            progress.refresh()  # render once, no animation
+
+    ts = datetime.now(ZoneInfo("Europe/Istanbul")).strftime("%Y%m%d_%H%M")
+    all_files = [f for _, file_list in files_by_script for f in file_list]
+    if fmt == "pdf":
+        dest = os.path.join(OUTPUT_DIR, f"dataset_{ts}.pdf")
+        merge_pdfs(files_by_script, dest)
+    else:
+        dest = os.path.join(OUTPUT_DIR, f"dataset_{ts}.zip")
+        create_zip(all_files, dest)
+
+    cleanup(all_files)
+    print(f"Created {dest}")

--- a/portfolio_exporter/scripts/update_tickers.py
+++ b/portfolio_exporter/scripts/update_tickers.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Update tickers_live.txt from current IBKR portfolio."""
+
+from __future__ import annotations
+import os
+from typing import List
+
+try:
+    from ib_insync import IB
+except ImportError:  # pragma: no cover - optional dependency
+    IB = None  # type: ignore
+
+IB_HOST, IB_PORT, IB_CID = "127.0.0.1", 7497, 4  # dedicated clientId
+PROXY_MAP = {"VIX": "^VIX", "VVIX": "^VVIX", "DXY": "DX-Y.NYB"}
+TICKERS_FILE = "tickers_live.txt"
+
+
+def fetch_ib_tickers() -> List[str]:
+    """Return stock tickers from current IBKR positions."""
+    if IB is None:
+        return []
+    ib = IB()
+    try:
+        ib.connect(IB_HOST, IB_PORT, clientId=IB_CID, timeout=3)
+    except Exception:
+        return []
+    positions = ib.positions()
+    ib.disconnect()
+    tickers = {
+        p.contract.symbol.upper()
+        for p in positions
+        if getattr(p.contract, "secType", "") == "STK"
+    }
+    return sorted(tickers)
+
+
+def save_tickers(tickers: List[str], path: str = TICKERS_FILE) -> None:
+    """Write tickers to a text file, one per line."""
+    with open(path, "w") as fh:
+        for tkr in tickers:
+            mapped = PROXY_MAP.get(tkr, tkr)
+            fh.write(f"{mapped}\n")
+
+
+def run(fmt: str = "csv") -> None:
+    """Update ticker list from IBKR positions."""
+    tickers = fetch_ib_tickers()
+    if not tickers:
+        print("No tickers retrieved from IBKR.")
+        return
+    save_tickers(tickers)
+    print(f"\u2705  Updated {TICKERS_FILE} with {len(tickers)} tickers.")

--- a/tests/test_pre_menu.py
+++ b/tests/test_pre_menu.py
@@ -1,0 +1,16 @@
+import types
+
+
+def test_pre_market_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "portfolio_exporter.scripts.update_tickers.run",
+        lambda fmt="csv": calls.append("tickers"),
+    )
+    import main, importlib
+
+    importlib.reload(main)
+    monkeypatch.setattr(main, "input", lambda _: "s\nr\n0")
+    main.parse_args = lambda: types.SimpleNamespace(quiet=True, format="csv")
+    main.main()
+    assert "tickers" in calls


### PR DESCRIPTION
## Summary
- port legacy exporters into `portfolio_exporter.scripts`
- replace hardcoded OUTPUT_DIR with configurable settings
- expose a new Pre‑Market submenu and wire into main
- provide `run()` entrypoints for new exporters
- test dispatch logic for the Pre‑Market menu

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e92000f9c832e8fcbdfce719396f3