### PR TITLE
feat(pre‑market): add External Technical Scan menu item (tech_scan.py)

### DIFF
--- a/portfolio_exporter/menus/pre.py
+++ b/portfolio_exporter/menus/pre.py
@@ -7,11 +7,21 @@ from portfolio_exporter.scripts import (
     option_chain_snapshot,
     net_liq_history_export,
     orchestrate_dataset,
+    tech_scan,
 )
 
 
 def launch(status: StatusBar, default_fmt: str):
     current_fmt = default_fmt
+
+    def _external_scan(fmt: str) -> None:
+        tickers = input("\u27b7  Enter tickers comma-separated: ").upper().split(",")
+        status.update(f"Tech scan: {','.join(tickers)} …", "cyan")
+        from portfolio_exporter.scripts import tech_scan
+
+        tech_scan.run(tickers=tickers, fmt=fmt)
+        status.update("Ready", "green")
+
     while True:
         tbl = Table(title="Pre-Market")
         for key, label in [
@@ -20,6 +30,7 @@ def launch(status: StatusBar, default_fmt: str):
             ("p", "Daily pulse"),
             ("o", "Option chain snapshot"),
             ("n", "Net-Liq history"),
+            ("x", "External technical scan"),
             ("z", "Run overnight batch"),
             ("f", f"Toggle output format (current: {current_fmt})"),
             ("r", "Return"),
@@ -40,6 +51,7 @@ def launch(status: StatusBar, default_fmt: str):
             "p": daily_pulse.run,
             "o": option_chain_snapshot.run,
             "n": net_liq_history_export.run,
+            "x": lambda fmt=default_fmt: _external_scan(fmt),
             "z": orchestrate_dataset.run,
         }.get(choice)
         if action:

--- a/portfolio_exporter/scripts/__init__.py
+++ b/portfolio_exporter/scripts/__init__.py
@@ -5,6 +5,7 @@ from . import (
     option_chain_snapshot,
     net_liq_history_export,
     orchestrate_dataset,
+    tech_scan,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "option_chain_snapshot",
     "net_liq_history_export",
     "orchestrate_dataset",
+    "tech_scan",
 ]

--- a/portfolio_exporter/scripts/tech_scan.py
+++ b/portfolio_exporter/scripts/tech_scan.py
@@ -1,0 +1,57 @@
+"""
+tech_scan.py  –  Ad-hoc technical-indicator exporter for arbitrary tickers.
+Usage (internal): run(tickers=["AAPL","SHOP"], fmt="csv")
+"""
+
+from typing import Sequence
+
+import pandas as pd
+import yfinance as yf
+
+from portfolio_exporter.core.io import save
+from portfolio_exporter.core.config import settings
+
+
+def _calc_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    out["sma_20"] = df["Close"].rolling(20).mean()
+    out["rsi_14"] = _rsi(df["Close"], 14)
+    out["macd"] = _macd(df["Close"])
+    return out
+
+
+def _rsi(series: pd.Series, n: int = 14) -> pd.Series:
+    delta = series.diff()
+    gain = (delta.where(delta > 0, 0)).rolling(n).mean()
+    loss = (-delta.where(delta < 0, 0)).rolling(n).mean()
+    rs = gain / loss
+    return 100 - (100 / (1 + rs))
+
+
+def _macd(
+    series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9
+) -> pd.Series:
+    ema_fast = series.ewm(span=fast, adjust=False).mean()
+    ema_slow = series.ewm(span=slow, adjust=False).mean()
+    macd = ema_fast - ema_slow
+    return macd
+
+
+# --------------------------------------------------------------------- #
+
+
+def run(tickers: Sequence[str], fmt: str = "csv") -> None:
+    frames = []
+    for t in tickers:
+        hist = yf.download(t, period="90d", progress=False)
+        if hist.empty:
+            continue
+        hist = hist.rename_axis("Date").reset_index()
+        ind = _calc_indicators(hist)
+        ind.insert(0, "Ticker", t)
+        frames.append(ind)
+    if not frames:
+        print("⚠️  No data downloaded.")
+        return
+    df = pd.concat(frames)
+    save(df, name="tech_scan", fmt=fmt, outdir=settings.output_dir)

--- a/tests/test_tech_scan.py
+++ b/tests/test_tech_scan.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import builtins
+from portfolio_exporter.scripts import tech_scan
+
+
+def test_tech_scan_saves(monkeypatch, tmp_path):
+    # Patch yfinance.download to return dummy OHLC
+    dummy = pd.DataFrame(
+        {
+            "Open": [1, 2, 3],
+            "High": [1, 2, 3],
+            "Low": [1, 2, 3],
+            "Close": [1, 2, 3],
+            "Adj Close": [1, 2, 3],
+            "Volume": [100, 120, 130],
+        },
+        index=pd.date_range("2024-01-01", periods=3),
+    )
+    monkeypatch.setattr("yfinance.download", lambda *a, **k: dummy)
+    # Patch io.save to capture format
+    saved = {}
+    monkeypatch.setattr(
+        "portfolio_exporter.core.io.save",
+        lambda df, name, fmt="csv", outdir=None: saved.setdefault("ok", fmt),
+    )
+    tech_scan.run(tickers=["ZZZZ"], fmt="pdf")
+    assert saved.get("ok") == "pdf"


### PR DESCRIPTION
## Summary
- implement ad-hoc technical indicator exporter in `tech_scan.py`
- wire new `x` action into pre-market menu
- expose the new script from `portfolio_exporter.scripts`
- test that the tech scan saves using the requested format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc1795eb4832eaa08c110d69f01d1