### PR TITLE
Add quote snapshot with fallback

### DIFF
--- a/portfolio_exporter/core/quotes.py
+++ b/portfolio_exporter/core/quotes.py
@@ -1,0 +1,34 @@
+import yfinance as yf
+from ib_insync import util, IB
+from typing import Sequence, Dict
+
+
+def _ibkr_quotes(tickers: Sequence[str]) -> Dict[str, float]:
+    ib = IB()
+    try:
+        ib.connect("127.0.0.1", 7497, clientId=12, timeout=2)
+    except Exception as e:
+        raise ConnectionError(str(e))
+    data = {}
+    for t in tickers:
+        contract = util.stock(t, "SMART", "USD")
+        q = ib.reqMktData(contract, "", False, False)
+        ib.sleep(1)
+        if q.last:
+            data[t] = q.last
+    ib.disconnect()
+    return data
+
+
+def _yf_quotes(tickers: Sequence[str]) -> Dict[str, float]:
+    df = yf.download(tickers, period="1d", interval="1m", progress=False)
+    if isinstance(df, tuple):
+        df = df[0]
+    return {t: float(df["Close"][t].dropna()[-1]) for t in tickers}
+
+
+def snapshot(tickers: Sequence[str]) -> Dict[str, float]:
+    try:
+        return _ibkr_quotes(tickers)
+    except ConnectionError:
+        return _yf_quotes(tickers)

--- a/portfolio_exporter/scripts/live_feed.py
+++ b/portfolio_exporter/scripts/live_feed.py
@@ -24,6 +24,7 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 from typing import List, Dict
+from portfolio_exporter.core.quotes import snapshot
 import numpy as np
 
 
@@ -721,4 +722,18 @@ def main():
 
 
 def run() -> None:
-    main()
+    tickers = load_tickers()
+    if not tickers:
+        return
+    data = snapshot(tickers)
+    ts_now = datetime.now(TR_TZ).strftime("%Y-%m-%dT%H:%M:%S%z")
+    df = pd.DataFrame({"ticker": list(data.keys()), "last": list(data.values())})
+    df.insert(0, "timestamp", ts_now)
+    base_q = OUTPUT_CSV.rsplit(".", 1)[0]
+    df.to_csv(
+        base_q + ".csv",
+        index=False,
+        quoting=csv.QUOTE_MINIMAL,
+        float_format="%.3f",
+    )
+    print(df)

--- a/tests/test_quote_fallback.py
+++ b/tests/test_quote_fallback.py
@@ -1,0 +1,14 @@
+import pandas as pd, types, pytest
+from portfolio_exporter.core import quotes
+
+
+def test_yf_fallback(monkeypatch):
+    # force ib to error
+    monkeypatch.setattr(
+        quotes, "_ibkr_quotes", lambda t: (_ for _ in ()).throw(ConnectionError)
+    )
+    # mock yfinance
+    dummy = pd.DataFrame({"Close": [1.23]}, index=[0])
+    monkeypatch.setattr(quotes, "_yf_quotes", lambda t: {"AAPL": 1.23})
+    out = quotes.snapshot(["AAPL"])
+    assert out["AAPL"] == 1.23


### PR DESCRIPTION
## Summary
- implement quote snapshot helper with IBKR then Yahoo fallback
- update `live_feed.py` to use new helper
- test fallback logic

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874eba7d1bc832e9e70ec9796341168