### PR TITLE
Sync dependencies post hybrid-quote

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,16 @@ requires-python = ">=3.11"
 license = "MIT"
 authors = [{name = "Codex", email = "codex@example.com"}]
 dependencies = [
-    "rich",
+    "fpdf",
+    "ib_insync",
+    "numpy",
+    "pandas",
     "prompt_toolkit",
     "pydantic-settings",
-    "ib_insync",
-    "yfinance",
-    "reportlab",
-    "fpdf",
     "pypdf",
-    "pandas",
-    "numpy",
+    "reportlab",
+    "rich",
+    "yfinance",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- reorder runtime dependencies after hybrid quote patch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f1c3ea94832e8faf81a40dbe4641