### PR TITLE
feat(trades): add Net-Liq chart preview (v key)

### DIFF
--- a/portfolio_exporter/menus/trade.py
+++ b/portfolio_exporter/menus/trade.py
@@ -1,13 +1,16 @@
 from rich.table import Table
+from rich.console import Console
 from portfolio_exporter.scripts import (
     trades_report,
     order_builder,
     roll_manager,
     option_chain_snapshot,
+    net_liq_history_export,
 )
 
 
 def launch(status, default_fmt):
+    console = status.console if status else Console()
     while True:
         tbl = Table(title="Trades & Reports")
         for k, lbl in [
@@ -15,10 +18,11 @@ def launch(status, default_fmt):
             ("b", "Build order (stub)"),
             ("l", "Roll positions (stub)"),
             ("q", "Quick option chain"),
+            ("v", "View Net-Liq chart"),
             ("r", "Return"),
         ]:
             tbl.add_row(k, lbl)
-        status.console.print(tbl)
+        console.print(tbl)
         ch = input("› ").strip().lower()
         if ch == "r":
             break
@@ -27,8 +31,11 @@ def launch(status, default_fmt):
             "b": order_builder.run,
             "l": roll_manager.run,
             "q": lambda: option_chain_snapshot.run(fmt=default_fmt),
+            "v": lambda: net_liq_history_export.run(fmt=default_fmt, plot=True),
         }.get(ch)
         if dispatch:
-            status.update(f"Running {lbl} …", "cyan")
+            if status:
+                status.update(f"Running {lbl} …", "cyan")
             dispatch()
-            status.update("Ready", "green")
+            if status:
+                status.update("Ready", "green")

--- a/portfolio_exporter/scripts/net_liq_history_export.py
+++ b/portfolio_exporter/scripts/net_liq_history_export.py
@@ -210,12 +210,11 @@ def _plot(df: pd.DataFrame, out_csv: Path):
 
 
 # ─────────────────────────── MAIN ──────────────────────────
-def run(fmt: str = "csv") -> None:
+def run(fmt: str = "csv", plot: bool = False) -> None:
     filetype = fmt.lower()
     args = argparse.Namespace(
         start=None,
         end=None,
-        plot=False,
         cp_download=False,
     )
 
@@ -234,6 +233,10 @@ def run(fmt: str = "csv") -> None:
     if df.empty:
         sys.exit("❌  No data in the selected date range.")
 
+    df = df.rename(columns={"net_liq": "NetLiq"})
     out_path = io.save(df.reset_index(), "net_liq_history_export", filetype)
-    if args.plot:
-        _plot(df, Path(out_path))
+    if plot:
+        import matplotlib.pyplot as plt
+
+        df["NetLiq"].plot(title="Net Liquidation History")
+        plt.show()

--- a/tests/test_net_liq_show.py
+++ b/tests/test_net_liq_show.py
@@ -1,0 +1,20 @@
+import builtins, types, importlib, main
+
+
+def test_netliq_chart_show(monkeypatch):
+    called = {}
+
+    def fake_run(fmt="csv", plot=False):
+        called["plot"] = plot
+
+    monkeypatch.setattr(
+        "portfolio_exporter.scripts.net_liq_history_export.run", fake_run
+    )
+    importlib.reload(main)
+    seq = iter(["3", "v", "r", "0"])
+    mock_input = lambda _="": next(seq)
+    monkeypatch.setattr(builtins, "input", mock_input)
+    monkeypatch.setattr(main, "input", mock_input)
+    main.parse_args = lambda: types.SimpleNamespace(quiet=True, format="csv")
+    main.main()
+    assert called.get("plot") is True

--- a/tests/test_trade_menu.py
+++ b/tests/test_trade_menu.py
@@ -9,7 +9,9 @@ def test_trade_menu_dispatch(monkeypatch):
     )
     importlib.reload(main)
     inp = iter(["3", "e", "r", "0"])
-    monkeypatch.setattr(builtins, "input", lambda _="": next(inp))
+    mock_input = lambda _="": next(inp)
+    monkeypatch.setattr(builtins, "input", mock_input)
+    monkeypatch.setattr(main, "input", mock_input)
     main.parse_args = lambda: types.SimpleNamespace(quiet=True, format="excel")
     main.main()
     assert "excel" in called


### PR DESCRIPTION
## Summary
- support inline charting in `net_liq_history_export.run`
- add `View Net-Liq chart` entry to the Trades menu
- update dispatch handling for the new command
- test chart preview via menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875275f1f0832ebc1acdc422bdc2df