### PR TITLE
Add interactive order builder

### DIFF
--- a/portfolio_exporter/menus/trade.py
+++ b/portfolio_exporter/menus/trade.py
@@ -15,7 +15,7 @@ def launch(status, default_fmt):
         tbl = Table(title="Trades & Reports")
         for k, lbl in [
             ("e", "Executions / open orders"),
-            ("b", "Build order (stub)"),
+            ("b", "Build order"),
             ("l", "Roll positions (stub)"),
             ("q", "Quick option chain"),
             ("v", "View Net-Liq chart"),

--- a/portfolio_exporter/scripts/order_builder.py
+++ b/portfolio_exporter/scripts/order_builder.py
@@ -1,2 +1,54 @@
-def run():  # placeholder
-    print("TODO – not implemented yet")
+"""
+order_builder.py – Interactive ticket wizard for simple strategies
+Currently supports:
+  • Covered call
+  • Cash-secured put
+  • Vertical spread (call or put)
+"""
+
+import builtins
+import datetime
+import json
+import pathlib
+from prompt_toolkit import prompt
+from portfolio_exporter.core.config import settings
+
+# Expose prompt_toolkit.prompt via a dotted builtins attribute for tests
+setattr(builtins, "prompt_toolkit.prompt", prompt)
+
+
+def _ask(question, default=None):
+    default_str = f" [{default}]" if default else ""
+    ask_fn = getattr(builtins, "prompt_toolkit.prompt", prompt)
+    return ask_fn(f"{question}{default_str}: ") or default
+
+
+def run():
+    strat = _ask("Strategy (cc/csp/vert)", "cc").lower()
+    underlying = _ask("Underlying", "TSLA").upper()
+    expiry = _ask(
+        "Expiry (YYYY-MM-DD)",
+        (datetime.date.today() + datetime.timedelta(weeks=2)).isoformat(),
+    )
+    qty = int(_ask("Contracts", "1"))
+    strikes = _ask("Strike(s) (comma-sep)").replace(" ", "")
+    strikes = [float(s) for s in strikes.split(",")]
+
+    ticket = {
+        "strategy": strat,
+        "underlying": underlying,
+        "expiry": expiry,
+        "qty": qty,
+        "strikes": strikes,
+        "account": settings.default_account,
+    }
+
+    # Save ticket to JSON in output_dir
+    out = pathlib.Path(settings.output_dir).expanduser() / "tickets"
+    out.mkdir(parents=True, exist_ok=True)
+    fn = (
+        out
+        / f"ticket_{underlying}_{expiry}_{datetime.datetime.now().strftime('%H%M%S')}.json"
+    )
+    fn.write_text(json.dumps(ticket, indent=2))
+    print(f"✅ Ticket saved to {fn}")

--- a/tests/test_order_builder.py
+++ b/tests/test_order_builder.py
@@ -1,0 +1,16 @@
+import builtins, types, pathlib, json
+from portfolio_exporter.scripts import order_builder
+from portfolio_exporter.core.config import settings
+
+
+def test_order_builder_creates_file(monkeypatch, tmp_path):
+    # Redirect output_dir to temp
+    monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+    answers = iter(["cc", "AAPL", "2099-01-01", "2", "150"])
+    monkeypatch.setattr(builtins, "prompt_toolkit.prompt", lambda x, **k: next(answers))
+    order_builder.run()
+    tickets = list((tmp_path / "tickets").glob("ticket_*.json"))
+    assert tickets, "No ticket file created"
+    data = json.loads(tickets[0].read_text())
+    assert data["underlying"] == "AAPL"
+    assert data["qty"] == 2


### PR DESCRIPTION
## Summary
- implement interactive ticket wizard for common strategies
- hook new script into trade menu
- test order builder file creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877f503a38832eab818e1fa72a85df