### PR TITLE
Add full-menu CLI smoke test

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,10 +6,12 @@ import sys
 from rich.console import Console
 from rich.table import Table
 from portfolio_exporter.menus.pre import _input as menu_input
+import builtins
 
 from portfolio_exporter.core.ui import StatusBar
 
 console = Console()
+input = builtins.input
 
 
 def build_menu() -> None:

--- a/portfolio_exporter/scripts/tech_scan.py
+++ b/portfolio_exporter/scripts/tech_scan.py
@@ -8,7 +8,7 @@ from typing import Sequence
 import pandas as pd
 import yfinance as yf
 
-from portfolio_exporter.core.io import save
+from portfolio_exporter.core import io
 from portfolio_exporter.core.config import settings
 
 
@@ -54,4 +54,4 @@ def run(tickers: Sequence[str], fmt: str = "csv") -> None:
         print("⚠️  No data downloaded.")
         return
     df = pd.concat(frames)
-    save(df, name="tech_scan", fmt=fmt, outdir=settings.output_dir)
+    io.save(df, name="tech_scan", fmt=fmt, outdir=settings.output_dir)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,66 @@
+"""
+Smoke-test the interactive CLI by simulating keystrokes for every
+currently-implemented menu item.  Heavy scripts are monkey-patched
+to lightweight stubs so the test runs in <1 s.
+"""
+
+import builtins
+import importlib
+import types
+import main
+from portfolio_exporter import scripts
+
+
+# 1-A  Patch ALL .run functions to fast stubs
+def _stub_runs(monkeypatch: types.SimpleNamespace) -> None:
+    for name in dir(scripts):
+        mod = getattr(scripts, name)
+        if isinstance(mod, types.ModuleType) and hasattr(mod, "run"):
+            monkeypatch.setattr(mod, "run", lambda *a, **k: None)
+
+
+# 1-B  Input sequence that walks every key:
+# Main: 1 Pre-Market  →  s h p o n z r
+#       2 Live-Market →  q t g r c b
+#       3 Trades      →  e b l q v r
+# Exit
+keys = [
+    "1",
+    "s",
+    "h",
+    "p",
+    "o",
+    "n",
+    "z",
+    "r",
+    "2",
+    "q",
+    "t",
+    "g",
+    "r",
+    "c",
+    "b",
+    "3",
+    "e",
+    "b",
+    "l",
+    "q",
+    "v",
+    "r",
+    "0",
+]
+seq = iter(keys)
+
+
+def fake_input(_=""):
+    return next(seq)
+
+
+def test_full_menu(monkeypatch):
+    _stub_runs(monkeypatch)
+    # force quiet mode for clean output
+    monkeypatch.setattr(builtins, "input", fake_input)
+    main.parse_args = lambda: types.SimpleNamespace(quiet=True, format="csv")
+    importlib.reload(main)
+    # should exit 0 without exceptions
+    main.main()


### PR DESCRIPTION
## Summary
- add a smoke test that walks the entire CLI menu
- expose `input` alias in `main` for monkeypatching
- call `io.save` via the module in `tech_scan` so tests can stub it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ac116660832eba63675569fa9efc