### PR TITLE
feat(trades): add Action (Buy/Sell/Close/Roll/Combo) to executions report

### DIFF
--- a/portfolio_exporter/menus/trade.py
+++ b/portfolio_exporter/menus/trade.py
@@ -27,7 +27,7 @@ def launch(status, default_fmt):
         if ch == "r":
             break
         dispatch = {
-            "e": lambda: trades_report.run(fmt=default_fmt),
+            "e": lambda: trades_report.run(fmt=default_fmt, show_actions=True),
             "b": order_builder.run,
             "l": roll_manager.run,
             "q": lambda: option_chain_snapshot.run(fmt=default_fmt),

--- a/tests/test_trade_menu.py
+++ b/tests/test_trade_menu.py
@@ -5,7 +5,7 @@ def test_trade_menu_dispatch(monkeypatch):
     called = []
     monkeypatch.setattr(
         "portfolio_exporter.scripts.trades_report.run",
-        lambda fmt="csv": called.append(fmt),
+        lambda fmt="csv", **_: called.append(fmt),
     )
     importlib.reload(main)
     inp = iter(["3", "e", "r", "0"])

--- a/tests/test_trades_report_actions.py
+++ b/tests/test_trades_report_actions.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pytest
+from portfolio_exporter.scripts import trades_report
+
+
+def test_action_tags(monkeypatch):
+    dummy = pd.DataFrame(
+        [
+            {
+                "secType": "OPT",
+                "Side": "BOT",
+                "Liquidation": 0,
+                "lastLiquidity": 1,
+                "OrderRef": "",
+            },
+            {
+                "secType": "OPT",
+                "Side": "SLD",
+                "Liquidation": 0,
+                "lastLiquidity": 1,
+                "OrderRef": "",
+            },
+            {
+                "secType": "OPT",
+                "Side": "SLD",
+                "Liquidation": 2,
+                "lastLiquidity": 2,
+                "OrderRef": "",
+            },
+            {
+                "secType": "BAG",
+                "Side": "BOT",
+                "Liquidation": 0,
+                "lastLiquidity": 1,
+                "OrderRef": "",
+            },
+            {
+                "secType": "OPT",
+                "Side": "BOT",
+                "Liquidation": 0,
+                "lastLiquidity": 1,
+                "OrderRef": "ROLL_123",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        "portfolio_exporter.scripts.trades_report._load_executions", lambda: dummy
+    )
+    df = trades_report.run(fmt="csv", show_actions=True, return_df=True)
+    assert list(df["Action"]) == ["Buy", "Sell", "Close", "Combo", "Roll"]


### PR DESCRIPTION
## Summary
- add `_classify` helper for trade action detection and update `trades_report.run` to expose `show_actions` and `return_df`
- persist trades report via core `save` helper and optionally return dataframe
- show Action column when launching executions report from trade menu
- cover classification logic with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c96a0d2a0832ea72624f04522afef