### PR TITLE
feat(greeks): export totals & per-position files; drop redundant main-menu option

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,11 @@ def input(prompt: str = "") -> str:
 
 
 def build_menu() -> None:
+    """Render the top-level menu.
+
+    The former "Portfolio Greeks" option was removed, leaving only the
+    pre‑market, live‑market and trades menus alongside exit.
+    """
     table = Table(title="AI-Managed Playbook – Main Menu")
     table.add_column("#")
     table.add_column("Function")

--- a/tests/test_portfolio_greeks_files.py
+++ b/tests/test_portfolio_greeks_files.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from pathlib import Path
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def test_greeks_dual_files(tmp_path, monkeypatch):
+    fake = pd.DataFrame(
+        [
+            {
+                "symbol": "FAKE",
+                "qty": 2,
+                "mult": 100,
+                "delta": 0.5,
+                "gamma": 0.1,
+                "vega": 0.2,
+                "theta": -0.05,
+            },
+            {
+                "symbol": "FOO",
+                "qty": 1,
+                "mult": 1,
+                "delta": 1.0,
+                "gamma": 0.2,
+                "vega": 0.3,
+                "theta": -0.02,
+            },
+        ]
+    )
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: fake)
+    # redirect output dir
+    monkeypatch.setattr(
+        "portfolio_exporter.core.config.settings",
+        type("X", (object,), {"output_dir": str(tmp_path)}),
+    )
+    portfolio_greeks.run(fmt="csv")
+    assert (tmp_path / "portfolio_greeks_totals.csv").exists()
+    assert (tmp_path / "portfolio_greeks_positions.csv").exists()

--- a/tests/test_portfolio_greeks_logic.py
+++ b/tests/test_portfolio_greeks_logic.py
@@ -30,7 +30,9 @@ def test_greeks_aggregation(monkeypatch):
         "portfolio_exporter.scripts.portfolio_greeks._load_positions", lambda: fake
     )
     # Run with return_dict to inspect exposures
-    result = portfolio_greeks.run(fmt="csv", return_dict=True)
+    result = portfolio_greeks.run(
+        fmt="csv", write_positions=False, write_totals=False, return_dict=True
+    )
     # Expected exposures = sum(qty*greek)
     assert result["delta_exposure"] == pytest.approx(2 * 0.5 + 1 * 1.0)
     assert result["gamma_exposure"] == pytest.approx(2 * 0.1 + 1 * 0.2)


### PR DESCRIPTION
## Summary
- add `_load_positions` hook and simplify `run` to export position and total greek exposures
- document that portfolio greeks menu item has been removed
- add regression test ensuring greek exports create both positions and totals files

## Testing
- `pytest -q`
- `python main.py --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688c975b2728832e89a3e0cdd48806d9