### PR TITLE
fix(batch): run helpers via package path; report failures

### DIFF
--- a/tests/test_orchestrate_batch.py
+++ b/tests/test_orchestrate_batch.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from portfolio_exporter.scripts import orchestrate_dataset as od
+from portfolio_exporter.scripts import (
+    daily_pulse,
+    historic_prices,
+    live_feed,
+    portfolio_greeks,
+)
+
+
+def _stub_factory(path: Path, name: str):
+    def _stub(fmt: str = "csv") -> None:  # type: ignore[unused-argument]
+        (path / f"{name}.{fmt}").write_text("data")
+
+    return _stub
+
+
+def test_orchestrate_dataset_run(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(od, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(od, "cleanup", lambda files: None)
+
+    monkeypatch.setattr(
+        historic_prices, "run", _stub_factory(tmp_path, "historic_prices")
+    )
+    monkeypatch.setattr(
+        portfolio_greeks, "run", _stub_factory(tmp_path, "portfolio_greeks")
+    )
+    monkeypatch.setattr(live_feed, "run", _stub_factory(tmp_path, "live_feed"))
+    monkeypatch.setattr(daily_pulse, "run", _stub_factory(tmp_path, "daily_pulse"))
+
+    od.run()
+
+    out = capsys.readouterr().out
+    assert "✅ Overnight batch completed – all files written." in out
+    for name in [
+        "historic_prices.csv",
+        "portfolio_greeks.csv",
+        "live_feed.csv",
+        "daily_pulse.csv",
+    ]:
+        assert (tmp_path / name).exists()


### PR DESCRIPTION
## Summary
- run nightly helper scripts via direct imports instead of subprocesses
- report any failed steps and summarize success or failure
- add unit test for orchestrated dataset batch

## Testing
- `pytest -q`
- `python -m portfolio_exporter.scripts.orchestrate_dataset`


------
https://chatgpt.com/codex/tasks/task_e_688cc3977004832e8d2a760e3e55c1dc