### PR TITLE
feat(trades): append open orders to executions report (Action = Open)

### DIFF
--- a/tests/test_trades_report_actions.py
+++ b/tests/test_trades_report_actions.py
@@ -44,7 +44,7 @@ def test_action_tags(monkeypatch):
         ]
     )
     monkeypatch.setattr(
-        "portfolio_exporter.scripts.trades_report._load_executions", lambda: dummy
+        "portfolio_exporter.scripts.trades_report._load_trades", lambda: dummy
     )
     df = trades_report.run(fmt="csv", show_actions=True, return_df=True)
     assert list(df["Action"]) == ["Buy", "Sell", "Close", "Combo", "Roll"]

--- a/tests/test_trades_report_open_orders.py
+++ b/tests/test_trades_report_open_orders.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+from portfolio_exporter.scripts import trades_report
+
+
+def test_include_open(monkeypatch):
+    execs = pd.DataFrame(
+        [
+            {
+                "Side": "BOT",
+                "secType": "OPT",
+                "Liquidation": 0,
+                "lastLiquidity": 1,
+                "OrderRef": "",
+                "symbol": "FAKE",
+            }
+        ]
+    )
+    opens = pd.DataFrame(
+        [
+            {
+                "symbol": "FAKE",
+                "secType": "OPT",
+                "Side": "BUY",
+                "Qty": 1,
+                "OrderRef": "",
+                "Action": "Open",
+            }
+        ]
+    )
+    monkeypatch.setattr(trades_report, "_load_trades", lambda: execs)
+    monkeypatch.setattr(trades_report, "_load_open_orders", lambda: opens)
+    out = trades_report.run(
+        fmt="csv", show_actions=True, include_open=True, return_df=True
+    )
+    assert len(out) == 2
+    assert "Open" in out["Action"].values


### PR DESCRIPTION
## Summary
- rename executions loader to `_load_trades` and add `_load_open_orders` to fetch open orders from IBKR tagged as `Action='Open'`
- update `run()` to accept `include_open` flag and merge open orders, preserving existing actions
- expand tests to cover open-order inclusion and adjust action tagging

## Testing
- `pytest -q`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ce52d1530832eafb45bd6400c9863