### PR TITLE
feat(core): live option/stock quoting helpers with IBKR snapshot & yfinance fallback

### DIFF
--- a/portfolio_exporter/core/chain.py
+++ b/portfolio_exporter/core/chain.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import itertools
+from typing import List
+
+import pandas as pd
+
+from .ib import quote_option, quote_stock
+
+
+def fetch_chain(
+    symbol: str, expiry: str, strikes: List[float] | None = None
+) -> pd.DataFrame:
+    """Return an option chain snapshot.
+
+    The resulting DataFrame includes columns: ``strike``, ``right``, ``mid``,
+    ``bid``, ``ask``, ``delta``, ``gamma``, ``vega``, ``theta`` and ``iv``.
+    """
+    if not strikes:
+        spot = quote_stock(symbol)["mid"]
+        strikes = [round((spot // 5 + i) * 5, 0) for i in range(-5, 6)]
+    rows = []
+    for strike, right in itertools.product(strikes, ["C", "P"]):
+        q = quote_option(symbol, expiry, strike, right)
+        q.update({"strike": strike, "right": right})
+        rows.append(q)
+    return pd.DataFrame(rows)

--- a/portfolio_exporter/core/ib.py
+++ b/portfolio_exporter/core/ib.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import contextlib
+import math
+from typing import Any, Dict
+
+import yfinance as yf
+from ib_insync import IB, Option, Stock
+
+_IB_HOST, _IB_PORT, _IB_CID = "127.0.0.1", 7497, 29
+
+_ib_singleton: IB | None = None
+
+
+def _ib() -> IB:
+    """Return a cached IB connection if available."""
+    global _ib_singleton
+    if _ib_singleton and _ib_singleton.isConnected():
+        return _ib_singleton
+    _ib_singleton = IB()
+    with contextlib.suppress(Exception):
+        _ib_singleton.connect(_IB_HOST, _IB_PORT, clientId=_IB_CID, timeout=2)
+    return _ib_singleton
+
+
+def quote_stock(symbol: str) -> Dict[str, Any]:
+    """Fetch snapshot quote for a stock.
+
+    Attempts IBKR first and falls back to yfinance.
+    """
+    ib = _ib()
+    if ib.isConnected():
+        stk = Stock(symbol, "SMART", "USD")
+        ticker = ib.reqMktData(stk, "", False, snapshot=True)
+        ib.sleep(0.3)
+        mid = (
+            (ticker.bid + ticker.ask) / 2 if ticker.bid and ticker.ask else ticker.last
+        )
+        return {"mid": mid, "bid": ticker.bid, "ask": ticker.ask}
+    yf_tkr = yf.Ticker(symbol)
+    price = yf_tkr.history(period="1d")["Close"].iloc[-1]
+    return {"mid": price, "bid": price, "ask": price}
+
+
+def quote_option(symbol: str, expiry: str, strike: float, right: str) -> Dict[str, Any]:
+    """Return price and greeks for an option contract.
+
+    Args:
+        symbol: Underlying symbol (e.g. ``"SPY"``).
+        expiry: Expiration in ``YYYY-MM-DD`` format.
+        strike: Strike price.
+        right: ``"C"`` for calls or ``"P"`` for puts.
+
+    Returns:
+        Dictionary with keys ``mid``, ``bid``, ``ask``, ``delta``, ``gamma``,
+        ``vega``, ``theta`` and ``iv``.
+    """
+    ib = _ib()
+    if ib.isConnected():
+        opt = Option(symbol, expiry, strike, right, "SMART")
+        ticker = ib.reqMktData(opt, "", False, snapshot=True)
+        ib.sleep(0.3)
+        mid = (
+            (ticker.bid + ticker.ask) / 2 if ticker.bid and ticker.ask else ticker.last
+        )
+        g = ticker.modelGreeks
+        return {
+            "mid": mid,
+            "bid": ticker.bid,
+            "ask": ticker.ask,
+            "delta": getattr(g, "delta", math.nan),
+            "gamma": getattr(g, "gamma", math.nan),
+            "vega": getattr(g, "vega", math.nan),
+            "theta": getattr(g, "theta", math.nan),
+            "iv": getattr(g, "impliedVol", math.nan),
+        }
+
+    yf_tkr = yf.Ticker(symbol)
+    chain = yf_tkr.option_chain(expiry)
+    tbl = chain.calls if right == "C" else chain.puts
+    row = tbl.loc[tbl["strike"] == strike]
+    if row.empty:
+        raise ValueError("Strike not found in yfinance chain")
+    mid = (row["bid"].values[0] + row["ask"].values[0]) / 2
+    return {
+        "mid": mid,
+        "bid": row["bid"].values[0],
+        "ask": row["ask"].values[0],
+        "delta": math.nan,
+        "gamma": math.nan,
+        "vega": math.nan,
+        "theta": math.nan,
+        "iv": row["impliedVolatility"].values[0],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pypdf",
     "reportlab",
     "rich",
-    "yfinance",
+    "yfinance>=0.2.37",
     "dateparser>=1.2.0",
 ]
 

--- a/tests/test_chain_fetch.py
+++ b/tests/test_chain_fetch.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from portfolio_exporter.core import chain
+
+
+def test_fetch_chain_stub(monkeypatch):
+    def fake_quote(symbol, expiry, strike, right):
+        return {
+            "mid": 1.23,
+            "bid": 1.2,
+            "ask": 1.26,
+            "delta": 0.5,
+            "gamma": 0.1,
+            "vega": 0.2,
+            "theta": -0.03,
+            "iv": 0.25,
+        }
+
+    monkeypatch.setattr(chain, "quote_option", fake_quote)
+    out = chain.fetch_chain("FAKE", "2099-01-01", strikes=[10, 12])
+    assert len(out) == 4
+    assert {"strike", "right", "mid", "delta", "iv"}.issubset(out.columns)

--- a/tests/test_quote_option_fallback.py
+++ b/tests/test_quote_option_fallback.py
@@ -1,0 +1,34 @@
+import math
+import types
+
+import pandas as pd
+from portfolio_exporter.core import ib as core_ib
+
+
+def test_quote_option_fallback(monkeypatch):
+    monkeypatch.setattr(core_ib, "_ib_singleton", None)
+    monkeypatch.setattr(core_ib, "_IB_PORT", 9999)
+
+    def fake_chain(self, date):
+        return types.SimpleNamespace(
+            calls=pd.DataFrame(
+                {
+                    "strike": [100],
+                    "bid": [1.0],
+                    "ask": [1.2],
+                    "impliedVolatility": [0.25],
+                }
+            ),
+            puts=pd.DataFrame(
+                {
+                    "strike": [100],
+                    "bid": [2.0],
+                    "ask": [2.2],
+                    "impliedVolatility": [0.30],
+                }
+            ),
+        )
+
+    monkeypatch.setattr("yfinance.Ticker.option_chain", fake_chain)
+    q = core_ib.quote_option("FAKE", "2099-01-01", 100, "C")
+    assert math.isclose(q["mid"], 1.1, rel_tol=1e-8)


### PR DESCRIPTION
## Summary
- add IBKR-backed stock/option quote helpers with yfinance fallback
- provide option chain fetcher for assembling bid/ask/greeks table
- require yfinance>=0.2.37

## Testing
- `pytest -q`
- `python - <<'PY'\nfrom portfolio_exporter.core.ib import quote_option\nprint(quote_option("SPY","2026-01-16",400,"C")["mid"])\nPY`


------
https://chatgpt.com/codex/tasks/task_e_688f7573c44c832eaad5cb89598ca249