### PR TITLE
feat(ui): unified Rich spinner; adopt across scripts

### DIFF
--- a/portfolio_exporter/scripts/daily_pulse.py
+++ b/portfolio_exporter/scripts/daily_pulse.py
@@ -18,6 +18,7 @@ import contextlib
 from portfolio_exporter.core.config import settings
 from portfolio_exporter.core import io
 from utils.progress import iter_progress
+from portfolio_exporter.core.ui import run_with_spinner
 from reportlab.lib.pagesizes import letter, landscape  # PDF output (landscape added)
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Spacer
 from reportlab.lib import colors
@@ -310,7 +311,7 @@ def run(fmt: str = "csv") -> None:
 
     # 2. technical data
     tickers = list(MARKET_OVERVIEW.keys()) + pos["ticker"].unique().tolist()
-    ohlc = fetch_ohlc(tickers)
+    ohlc = run_with_spinner("Fetching price data…", fetch_ohlc, tickers)
     tech = compute_indicators(ohlc)
     tech_last = last_row(tech)[INDICATORS].round(3)
 

--- a/portfolio_exporter/scripts/historic_prices.py
+++ b/portfolio_exporter/scripts/historic_prices.py
@@ -3,6 +3,7 @@ import csv
 import argparse
 from portfolio_exporter.core.config import settings
 from portfolio_exporter.core import io
+from portfolio_exporter.core.ui import run_with_spinner
 import pandas as pd
 import yfinance as yf
 
@@ -201,5 +202,5 @@ def save_to_pdf(df: pd.DataFrame, path: str) -> None:
 def run(fmt: str = "csv") -> None:
     """Export historical prices using ``fmt`` extension."""
     tickers = load_tickers()
-    df = fetch_and_prepare_data(tickers)
+    df = run_with_spinner("Fetching price history…", fetch_and_prepare_data, tickers)
     io.save(df, "historic_prices", fmt.lower())

--- a/portfolio_exporter/scripts/live_feed.py
+++ b/portfolio_exporter/scripts/live_feed.py
@@ -25,6 +25,7 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 from typing import List, Dict
 from portfolio_exporter.core.quotes import snapshot
+from portfolio_exporter.core.ui import run_with_spinner
 import numpy as np
 
 
@@ -762,7 +763,7 @@ def run(
     if include_indices:
         tickers = sorted(set(t.upper() for t in tickers) | set(ALWAYS_TICKERS))
 
-    df = _snapshot_quotes(tickers, fmt=fmt)
+    df = run_with_spinner("Fetching quotes…", _snapshot_quotes, tickers, fmt=fmt)
     df = df.rename(columns={"symbol": "ticker", "price": "last"})
     ts_now = datetime.now(TR_TZ).strftime("%Y-%m-%dT%H:%M:%S%z")
     df.insert(0, "timestamp", ts_now)

--- a/portfolio_exporter/scripts/option_chain_snapshot.py
+++ b/portfolio_exporter/scripts/option_chain_snapshot.py
@@ -28,6 +28,7 @@ import os
 import time
 from portfolio_exporter.core.config import settings
 from portfolio_exporter.core import io
+from portfolio_exporter.core.ui import run_with_spinner
 from datetime import datetime, timezone, date
 from typing import List, Sequence
 import zipfile
@@ -732,7 +733,9 @@ def run(fmt: str = "csv") -> None:
         hints = hints or [expiry_hint]
         for hint in hints:
             try:
-                df = snapshot_chain(ib, sym, hint)
+                df = run_with_spinner(
+                    f"Fetching {sym} chain…", snapshot_chain, ib, sym, hint
+                )
                 if df.empty:
                     logger.warning("%s %s – no data", sym, hint)
                     continue

--- a/portfolio_exporter/scripts/portfolio_greeks.py
+++ b/portfolio_exporter/scripts/portfolio_greeks.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 from utils.bs import bs_greeks
 from legacy.option_chain_snapshot import fetch_yf_open_interest
+from portfolio_exporter.core.ui import run_with_spinner
 
 import numpy as np
 import pandas as pd
@@ -1029,7 +1030,7 @@ def run(
 ) -> dict | None:
     """Aggregate per-position Greeks and optionally persist the results."""
 
-    pos = _load_positions().copy()
+    pos = run_with_spinner("Fetching positions…", _load_positions).copy()
 
     # ensure contract multipliers are populated correctly
     pos.loc[(pos.secType == "OPT") & (pos.multiplier.isna()), "multiplier"] = 100

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    PE_QUIET=1

--- a/tests/test_spinner_helper.py
+++ b/tests/test_spinner_helper.py
@@ -1,0 +1,5 @@
+from portfolio_exporter.core.ui import run_with_spinner
+
+
+def test_run_with_spinner_returns_value():
+    assert run_with_spinner("msg", lambda x: x + 1, 41) == 42


### PR DESCRIPTION
## Summary
- add console-aware spinner helpers to core UI
- wrap network operations across scripts to show spinner progress
- ensure tests run quietly with PE_QUIET and verify spinner helper

## Testing
- `pytest -q`
- `python main.py` (portfolio greeks menu, fails to connect to IB but spinner runs)


------
https://chatgpt.com/codex/tasks/task_e_68906d5fa748832e9f73eb4e67ca042b