### PR TITLE
feat(combo): detect verticals & straddles, persist mapping; output combos file

### DIFF
--- a/portfolio_exporter/core/combo.py
+++ b/portfolio_exporter/core/combo.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import logging
+import pathlib
+import sqlite3
+from typing import Dict, List
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+# ── database setup ────────────────────────────────────────────────────────────
+DB_PATH = pathlib.Path.home() / ".portfolio_exporter" / "combos.db"
+DB_PATH.parent.mkdir(exist_ok=True)
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS combos (
+    combo_id TEXT PRIMARY KEY,
+    ts_created TEXT,
+    ts_closed TEXT,
+    structure TEXT,
+    underlying TEXT,
+    expiry TEXT
+);
+CREATE TABLE IF NOT EXISTS legs (
+    combo_id TEXT,
+    conid INTEGER,
+    strike REAL,
+    right TEXT,
+    PRIMARY KEY(combo_id, conid)
+);
+"""
+
+
+def _db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.executescript(_DDL)
+    return conn
+
+
+# ---------- util helpers --------------------------------------------------
+def _hash_combo(conids: List[int]) -> str:
+    h = hashlib.sha256()
+    for cid in sorted(conids):
+        h.update(str(cid).encode())
+    return h.hexdigest()[:16]
+
+
+# ---------- public API ----------------------------------------------------
+def detect_combos(pos_df: pd.DataFrame) -> pd.DataFrame:
+    """Group legs into combos and persist mapping.
+
+    ``pos_df`` must be indexed by ``conId`` and include the following columns:
+    ``underlying``, ``qty``, ``right``, ``strike``, ``expiry``,
+    ``delta``, ``gamma``, ``vega`` and ``theta``.
+
+    Returns a DataFrame with one row per combo summarising the greeks and
+    including the list of legs.
+    """
+
+    combos: List[Dict] = []
+    used: set[int] = set()
+
+    # 1) try to match verticals
+    for idx, leg in pos_df.iterrows():
+        if idx in used or leg["right"] not in {"C", "P"}:
+            continue
+        opp = pos_df[
+            (pos_df["underlying"] == leg["underlying"])
+            & (pos_df["expiry"] == leg["expiry"])
+            & (pos_df["right"] == leg["right"])
+            & (pos_df["qty"] == -leg["qty"])
+        ]
+        opp = opp[opp.index != idx]  # exclude itself
+        if len(opp) == 1:
+            other = opp.iloc[0]
+            legs_idx = [idx, other.name]
+            used.update(legs_idx)
+            combos.append(
+                _row(
+                    "VertCall" if leg["right"] == "C" else "VertPut",
+                    pos_df.loc[legs_idx],
+                )
+            )
+            continue
+
+    # 2) single straddles (buy or sell)
+    for conids in _pair_same_strike(pos_df, used):
+        used.update(conids)
+        combos.append(_row("Straddle", pos_df.loc[conids]))
+
+    # 3) group leftover singles
+    for idx in pos_df.index.difference(used):
+        combos.append(_row("Single", pos_df.loc[[idx]]))
+
+    combo_df = pd.DataFrame(combos)
+    if combo_df.empty:
+        combo_df = pd.DataFrame(
+            columns=[
+                "combo_id",
+                "structure",
+                "underlying",
+                "expiry",
+                "qty",
+                "delta",
+                "gamma",
+                "vega",
+                "theta",
+                "legs",
+            ]
+        ).set_index("combo_id")
+    else:
+        combo_df = combo_df.set_index("combo_id")
+    _sync_with_db(combo_df, pos_df)
+    return combo_df
+
+
+# ---------- helpers -------------------------------------------------------
+def _row(structure: str, legs_df: pd.DataFrame) -> Dict:
+    combo_id = _hash_combo(list(legs_df.index))
+    return dict(
+        combo_id=combo_id,
+        structure=structure,
+        underlying=legs_df["underlying"].iloc[0],
+        expiry=legs_df["expiry"].iloc[0],
+        qty=legs_df["qty"].sum(),
+        delta=legs_df["delta"].sum(),
+        gamma=legs_df["gamma"].sum(),
+        vega=legs_df["vega"].sum(),
+        theta=legs_df["theta"].sum(),
+        legs=list(legs_df.index),
+    )
+
+
+def _pair_same_strike(df: pd.DataFrame, used: set[int]) -> List[List[int]]:
+    mask = ~df.index.isin(used)
+    sub = df[mask]
+    pairs: List[List[int]] = []
+    for (u, strk, exp), grp in sub.groupby(["underlying", "strike", "expiry"]):
+        if {"C", "P"} <= set(grp["right"]) and grp["qty"].nunique() == 1:
+            pairs.append(list(grp.index))
+    return pairs
+
+
+def _sync_with_db(combo_df: pd.DataFrame, pos_df: pd.DataFrame) -> None:
+    conn = _db()
+    now = _dt.datetime.utcnow().isoformat(timespec="seconds")
+
+    # mark inactive combo_ids as closed
+    active = set(combo_df.index)
+    cur = conn.execute("SELECT combo_id, ts_closed FROM combos")
+    for cid, ts_closed in cur.fetchall():
+        if cid not in active and ts_closed is None:
+            conn.execute("UPDATE combos SET ts_closed=? WHERE combo_id=?", (now, cid))
+
+    # upsert active combos and legs
+    for cid, row in combo_df.iterrows():
+        conn.execute(
+            "INSERT OR IGNORE INTO combos VALUES (?,?,?,?,?,?)",
+            (cid, now, None, row.structure, row.underlying, row.expiry),
+        )
+        for conid in row.legs:
+            leg = pos_df.loc[conid]
+            conn.execute(
+                "INSERT OR IGNORE INTO legs VALUES (?,?,?,?)",
+                (cid, int(conid), leg.strike, leg.right),
+            )
+
+    conn.commit()
+
+
+def fetch_persisted_mapping() -> Dict[int, str]:
+    """Return mapping of ``conid`` to ``combo_id`` from the SQLite store."""
+
+    conn = _db()
+    return {cid: cmb for cid, cmb in conn.execute("SELECT conid, combo_id FROM legs")}

--- a/portfolio_exporter/core/io.py
+++ b/portfolio_exporter/core/io.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 import pandas as pd
+from .config import settings
 
 
 def save(
     df: pd.DataFrame, name: str, fmt: str = "csv", outdir: str | Path | None = None
 ):
     outdir = Path(
-        outdir or "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/Downloads"
+        outdir
+        or "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/Downloads"
     ).expanduser()
     outdir.mkdir(parents=True, exist_ok=True)
     fname = outdir / f"{name}.{ {'csv':'csv','excel':'xlsx','pdf':'pdf'}[fmt] }"
@@ -20,3 +22,29 @@ def save(
         df.to_html(fname.with_suffix(".html"), index=False)
         # simple html→pdf placeholder; real impl later
     return fname
+
+
+def latest_file(
+    name: str, fmt: str = "csv", outdir: str | Path | None = None
+) -> Path | None:
+    """Return most recent file for *name* and *fmt* in *outdir*.
+
+    Parameters
+    ----------
+    name:
+        Base file name without timestamp suffix.
+    fmt:
+        File format extension, e.g. ``"csv"``.
+    outdir:
+        Directory to search; defaults to settings.output_dir.
+
+    Returns
+    -------
+    pathlib.Path | None
+        Path to most recent matching file or ``None`` if none found.
+    """
+
+    outdir = Path(outdir or settings.output_dir).expanduser()
+    pattern = f"{name}*.{fmt}"
+    files = sorted(outdir.glob(pattern))
+    return files[-1] if files else None

--- a/tests/test_combo_matcher.py
+++ b/tests/test_combo_matcher.py
@@ -1,0 +1,81 @@
+import pandas as pd
+
+from portfolio_exporter.core.combo import detect_combos
+
+
+def test_detects_verticals_and_straddles(tmp_path, monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "underlying": "AAPL",
+                "qty": 1,
+                "right": "C",
+                "strike": 100,
+                "expiry": "20240119",
+                "delta": 0.5,
+                "gamma": 0.1,
+                "vega": 0.2,
+                "theta": -0.05,
+            },
+            {
+                "underlying": "AAPL",
+                "qty": -1,
+                "right": "C",
+                "strike": 105,
+                "expiry": "20240119",
+                "delta": -0.4,
+                "gamma": -0.08,
+                "vega": -0.15,
+                "theta": 0.04,
+            },
+            {
+                "underlying": "MSFT",
+                "qty": 1,
+                "right": "C",
+                "strike": 300,
+                "expiry": "20240119",
+                "delta": 0.6,
+                "gamma": 0.05,
+                "vega": 0.1,
+                "theta": -0.02,
+            },
+            {
+                "underlying": "MSFT",
+                "qty": 1,
+                "right": "P",
+                "strike": 300,
+                "expiry": "20240119",
+                "delta": -0.4,
+                "gamma": 0.04,
+                "vega": 0.09,
+                "theta": -0.01,
+            },
+            {
+                "underlying": "TSLA",
+                "qty": 1,
+                "right": "C",
+                "strike": 200,
+                "expiry": "20240119",
+                "delta": 0.3,
+                "gamma": 0.02,
+                "vega": 0.05,
+                "theta": -0.01,
+            },
+        ],
+        index=[101, 102, 201, 202, 301],
+    )
+
+    combos = detect_combos(df)
+
+    assert len(combos) == 3
+    structures = set(combos.structure)
+    assert structures == {"VertCall", "Straddle", "Single"}
+
+    vert = combos[combos.structure == "VertCall"].iloc[0]
+    assert set(vert.legs) == {101, 102}
+
+    straddle = combos[combos.structure == "Straddle"].iloc[0]
+    assert set(straddle.legs) == {201, 202}
+
+    single = combos[combos.structure == "Single"].iloc[0]
+    assert single.legs == [301]

--- a/tests/test_combo_persistence.py
+++ b/tests/test_combo_persistence.py
@@ -1,0 +1,59 @@
+import sqlite3
+import pandas as pd
+
+from portfolio_exporter.core import combo
+
+
+def test_persists_and_closes(tmp_path, monkeypatch):
+    db_path = tmp_path / "combos.db"
+    monkeypatch.setattr(combo, "DB_PATH", db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    df = pd.DataFrame(
+        [
+            {
+                "underlying": "AAPL",
+                "qty": 1,
+                "right": "C",
+                "strike": 100,
+                "expiry": "20240119",
+                "delta": 0.5,
+                "gamma": 0.1,
+                "vega": 0.2,
+                "theta": -0.05,
+            },
+            {
+                "underlying": "AAPL",
+                "qty": -1,
+                "right": "C",
+                "strike": 105,
+                "expiry": "20240119",
+                "delta": -0.4,
+                "gamma": -0.08,
+                "vega": -0.15,
+                "theta": 0.04,
+            },
+        ],
+        index=[1, 2],
+    )
+
+    combos_df = combo.detect_combos(df)
+    mapping = combo.fetch_persisted_mapping()
+    assert mapping == {1: combos_df.index[0], 2: combos_df.index[0]}
+
+    conn = sqlite3.connect(db_path)
+    ts_closed = conn.execute(
+        "SELECT ts_closed FROM combos WHERE combo_id=?", (combos_df.index[0],)
+    ).fetchone()[0]
+    conn.close()
+    assert ts_closed is None
+
+    # Now call with empty positions -> combo should be marked closed
+    combo.detect_combos(df.iloc[0:0])
+
+    conn = sqlite3.connect(db_path)
+    ts_closed2 = conn.execute(
+        "SELECT ts_closed FROM combos WHERE combo_id=?", (combos_df.index[0],)
+    ).fetchone()[0]
+    conn.close()
+    assert ts_closed2 is not None

--- a/tests/test_portfolio_greeks_files.py
+++ b/tests/test_portfolio_greeks_files.py
@@ -6,26 +6,33 @@ def test_greeks_files(monkeypatch, tmp_path):
     fake = pd.DataFrame(
         [
             {
-                "symbol": "OPT1",
+                "underlying": "OPT1",
                 "secType": "OPT",
                 "qty": 1,
                 "multiplier": 100,
+                "right": "C",
+                "strike": 10,
+                "expiry": "20240101",
                 "delta": 0.5,
                 "gamma": 0.1,
                 "vega": 0.3,
                 "theta": -0.04,
             },
             {
-                "symbol": "STK1",
+                "underlying": "STK1",
                 "secType": "STK",
                 "qty": 50,
                 "multiplier": 1,
+                "right": "",
+                "strike": 0.0,
+                "expiry": "",
                 "delta": 1.0,
                 "gamma": 0.0,
                 "vega": 0.0,
                 "theta": 0.0,
             },
-        ]
+        ],
+        index=[1, 2],
     )
     monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: fake)
     monkeypatch.setattr(

--- a/tests/test_portfolio_greeks_live_stub.py
+++ b/tests/test_portfolio_greeks_live_stub.py
@@ -8,27 +8,34 @@ def test_live_loader_is_overridable(monkeypatch):
     fake = pd.DataFrame(
         [
             {
-                "symbol": "FAKE",
+                "underlying": "FAKE",
                 "secType": "OPT",
                 "qty": 1,
                 "multiplier": 100,
+                "right": "C",
+                "strike": 10,
+                "expiry": "20240101",
                 "delta": 0.5,
                 "gamma": 0.1,
                 "vega": 0.2,
                 "theta": -0.03,
             },
             {
-                "symbol": "FAK2",
+                "underlying": "FAK2",
                 "secType": "STK",
                 "qty": 50,
                 "multiplier": 1,
+                "right": "",
+                "strike": 0.0,
+                "expiry": "",
                 "delta": 1.0,
                 "gamma": 0.0,
                 "vega": 0.0,
                 "theta": 0.0,
             },
-        ]
+        ],
+        index=[1, 2],
     )
     monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: fake)
     res = portfolio_greeks.run(return_dict=True)
-    assert res["delta_exposure"] == pytest.approx(0.5 * 100 * 1 + 50 * 1 * 1.0)
+    assert res["legs"]["delta_exposure"] == pytest.approx(0.5 * 100 * 1 + 50 * 1 * 1.0)

--- a/tests/test_portfolio_greeks_logic.py
+++ b/tests/test_portfolio_greeks_logic.py
@@ -1,44 +1,52 @@
 import pandas as pd
 import pytest
+
 from portfolio_exporter.scripts import portfolio_greeks
 
 
 def test_greeks_aggregation(monkeypatch):
-    # Create fake positions with known greeks
     fake = pd.DataFrame(
         [
             {
-                "symbol": "FAKE",
+                "underlying": "FAKE",
                 "secType": "STK",
                 "qty": 2,
                 "multiplier": 1,
+                "right": "",
+                "strike": 0.0,
+                "expiry": "",
                 "delta": 0.5,
                 "gamma": 0.1,
                 "vega": 0.2,
                 "theta": -0.05,
             },
             {
-                "symbol": "FOO",
+                "underlying": "FOO",
                 "secType": "STK",
                 "qty": 1,
                 "multiplier": 1,
+                "right": "",
+                "strike": 0.0,
+                "expiry": "",
                 "delta": 1.0,
                 "gamma": 0.2,
                 "vega": 0.3,
                 "theta": -0.02,
             },
-        ]
+        ],
+        index=[1, 2],
     )
-    # Monkeypatch the function that loads positions
+
     monkeypatch.setattr(
         "portfolio_exporter.scripts.portfolio_greeks._load_positions", lambda: fake
     )
-    # Run with return_dict to inspect exposures
+
     result = portfolio_greeks.run(
         fmt="csv", write_positions=False, write_totals=False, return_dict=True
     )
-    # Expected exposures = sum(qty*greek)
-    assert result["delta_exposure"] == pytest.approx(2 * 0.5 + 1 * 1.0)
-    assert result["gamma_exposure"] == pytest.approx(2 * 0.1 + 1 * 0.2)
-    assert result["vega_exposure"] == pytest.approx(2 * 0.2 + 1 * 0.3)
-    assert result["theta_exposure"] == pytest.approx(2 * -0.05 + 1 * -0.02)
+    legs = result["legs"]
+
+    assert legs["delta_exposure"] == pytest.approx(2 * 0.5 + 1 * 1.0)
+    assert legs["gamma_exposure"] == pytest.approx(2 * 0.1 + 1 * 0.2)
+    assert legs["vega_exposure"] == pytest.approx(2 * 0.2 + 1 * 0.3)
+    assert legs["theta_exposure"] == pytest.approx(2 * -0.05 + 1 * -0.02)


### PR DESCRIPTION
## Summary
- add combo matcher that identifies verticals, straddles and singles while persisting leg→combo mappings
- export combo-level Greeks in `portfolio_greeks` and expose them through CLI/menus
- update live menu to report legs vs combos from latest export

## Testing
- `pytest -q`
- `python -m portfolio_exporter.scripts.portfolio_greeks`


------
https://chatgpt.com/codex/tasks/task_e_68907b424690832eb7378658dcaf81fc