### PR TITLE
Handle missing option right column

### DIFF
--- a/portfolio_exporter/core/combo.py
+++ b/portfolio_exporter/core/combo.py
@@ -60,6 +60,10 @@ def detect_combos(pos_df: pd.DataFrame) -> pd.DataFrame:
     including the list of legs.
     """
 
+    # guarantee the column is present (stock legs will have <NA>)
+    if "right" not in pos_df.columns:
+        pos_df["right"] = pd.NA
+
     combos: List[Dict] = []
     used: set[int] = set()
 

--- a/portfolio_exporter/scripts/portfolio_greeks.py
+++ b/portfolio_exporter/scripts/portfolio_greeks.py
@@ -991,9 +991,13 @@ def _load_positions() -> pd.DataFrame:  # pragma: no cover - replaced in tests
         opt_rows.append(
             {
                 "symbol": c.localSymbol,
+                "underlying": c.symbol,
                 "secType": c.secType,
                 "qty": qty,
                 "multiplier": mult,
+                "right": getattr(c, "right", None),  # "C"/"P" for options
+                "strike": getattr(c, "strike", None),
+                "expiry": getattr(c, "lastTradeDateOrContractMonth", None),
                 "delta": src.delta,
                 "gamma": src.gamma,
                 "vega": src.vega,
@@ -1008,9 +1012,13 @@ def _load_positions() -> pd.DataFrame:  # pragma: no cover - replaced in tests
             stk_rows.append(
                 {
                     "symbol": p.contract.symbol,
+                    "underlying": p.contract.symbol,
                     "secType": p.contract.secType,
                     "qty": p.position,
                     "multiplier": 1,
+                    "right": None,
+                    "strike": None,
+                    "expiry": None,
                     # shares: delta = 1, other greeks 0
                     "delta": 1.0,
                     "gamma": 0.0,


### PR DESCRIPTION
## Summary
- guard combo detection by inserting a missing `right` column
- enrich position loading with option metadata including `right`, `strike`, and `expiry`

## Testing
- `pytest -q`
- `OUTPUT_DIR=. PE_TEST_MODE=1 python -m portfolio_exporter.scripts.portfolio_greeks --fmt csv`


------
https://chatgpt.com/codex/tasks/task_e_6890862d3054832ea8f1746b393bc9cb