### PR TITLE
feat(roll): add Roll-Wizard with ticket + preview CSV

### DIFF
--- a/portfolio_exporter/config/settings.yaml
+++ b/portfolio_exporter/config/settings.yaml
@@ -2,3 +2,7 @@ output_dir: "/Users/yordamkocatepe/Library/Mobile Documents/com~apple~CloudDocs/
 timezone: "Europe/Istanbul"
 broker: "IBKR"
 default_account: "UXXXXXXX"
+roll:
+  slippage: 0.05           # $0.05 off mid
+  default_days: 7
+  use_weekly: false

--- a/portfolio_exporter/menus/trade.py
+++ b/portfolio_exporter/menus/trade.py
@@ -1,5 +1,5 @@
-from rich.table import Table
 from rich.console import Console
+from rich.table import Table
 from portfolio_exporter.scripts import (
     trades_report,
     order_builder,
@@ -18,7 +18,7 @@ def launch(status, default_fmt):
         for k, lbl in [
             ("e", "Executions / open orders"),
             ("b", "Build order"),
-            ("l", "Roll positions (stub)"),
+            ("l", "Roll positions"),
             ("q", "Quick option chain"),
             ("v", "View Net-Liq chart"),
             ("r", "Return"),
@@ -31,7 +31,7 @@ def launch(status, default_fmt):
         dispatch = {
             "e": lambda: trades_report.run(fmt=default_fmt, show_actions=True),
             "b": order_builder.run,
-            "l": roll_manager.run,
+            "l": lambda: roll_manager.run(),
             "q": lambda: option_chain_snapshot.run(fmt=default_fmt),
             "v": lambda: net_liq_history_export.run(fmt=default_fmt, plot=True),
         }.get(ch)

--- a/portfolio_exporter/scripts/roll_manager.py
+++ b/portfolio_exporter/scripts/roll_manager.py
@@ -1,2 +1,254 @@
-def run():  # placeholder
-    print("TODO – not implemented yet")
+"""roll_manager.py – helper to roll expiring option combos.
+
+This module provides a small interactive wizard that inspects the current
+portfolio, highlights option combos that are close to expiry and helps the user
+generate a JSON ticket and CSV preview for rolling those positions.
+
+The implementation in this kata is deliberately lightweight.  Network calls are
+wrapped with ``run_with_spinner`` which keeps the behaviour consistent with the
+rest of the project while remaining easy to stub in tests.
+"""
+
+from __future__ import annotations
+
+import calendar
+import datetime as dt
+import json
+import pathlib
+from typing import List
+
+import pandas as pd
+from rich.console import Console
+from rich.table import Table
+
+from portfolio_exporter.core.combo import detect_combos
+from portfolio_exporter.core.chain import fetch_chain
+from portfolio_exporter.core.config import settings
+from portfolio_exporter.core.ui import run_with_spinner
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def _third_friday(year: int, month: int) -> dt.date:
+    """Return the date of the third Friday for ``year``/``month``."""
+
+    cal = calendar.monthcalendar(year, month)
+    return dt.date(year, month, cal[2][calendar.FRIDAY])
+
+
+def _next_expiry(today: dt.date, weekly: bool) -> str:
+    """Calculate the next target expiry as ISO date string."""
+
+    if weekly:
+        start = today + dt.timedelta(weeks=1)
+        while start.weekday() != 4:  # Friday
+            start += dt.timedelta(days=1)
+        return start.isoformat()
+
+    month = today.month + 1
+    year = today.year + (1 if month == 13 else 0)
+    month = 1 if month == 13 else month
+    exp = _third_friday(year, month)
+    if (exp - today).days < 7:
+        month += 1
+        if month == 13:
+            month = 1
+            year += 1
+        exp = _third_friday(year, month)
+    return exp.isoformat()
+
+
+def _write_files(df: pd.DataFrame, pos_df: pd.DataFrame) -> None:
+    """Persist ticket JSON and CSV preview for selected rolls."""
+
+    if df.empty:
+        return
+
+    outdir = pathlib.Path(settings.output_dir).expanduser()
+    outdir.mkdir(parents=True, exist_ok=True)
+    ts = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    ticket_path = outdir / f"roll_ticket_{ts}.json"
+    preview_path = outdir / f"roll_preview_{ts}.csv"
+
+    combos_out = []
+    for _, row in df.iterrows():
+        legs_close = [
+            {"conId": int(l), "qty": int(pos_df.loc[l, "qty"])} for l in row.legs_old
+        ]
+        legs_open = [
+            {
+                "symbol": row.underlying,
+                "expiry": row.new_exp,
+                "strike": leg["strike"],
+                "right": leg["right"],
+                "qty": leg["qty"],
+            }
+            for leg in row.legs_new
+        ]
+        combos_out.append(
+            {
+                "underlying": row.underlying,
+                "legs_close": legs_close,
+                "legs_open": legs_open,
+                "limit": round(float(row.debit_credit), 2),
+            }
+        )
+
+    ticket = {"timestamp": dt.datetime.utcnow().isoformat(), "combos": combos_out}
+    ticket_path.write_text(json.dumps(ticket, indent=2))
+
+    csv_df = pd.DataFrame(
+        {
+            "underlying": df.underlying,
+            "old_expiry": df.old_exp,
+            "new_expiry": df.new_exp,
+            "qty": df.qty,
+            "debit_credit": df.debit_credit,
+            "Δ_before": df.delta_before,
+            "Δ_after": df.delta_after,
+            "Θ_before": df.theta_before,
+            "Θ_after": df.theta_after,
+        }
+    )
+    csv_df.to_csv(preview_path, index=False)
+
+
+def run(
+    days: int | None = None,
+    weekly: bool | None = None,
+    fmt: str = "csv",
+    return_df: bool = False,
+):
+    """Interactive roll manager.
+
+    Parameters
+    ----------
+    days : int | None
+        Filter combos expiring within this many days.  When ``None`` the value
+        is pulled from ``settings`` with a default of ``7``.
+    weekly : bool | None
+        ``True`` for weekly rolls, ``False`` for monthly.  ``None`` defers to the
+        configuration.
+    fmt : str
+        Placeholder for future output formats.  Currently only ``csv`` is
+        produced but the argument keeps parity with other scripts.
+    return_df : bool
+        When ``True`` the DataFrame of candidate rolls is returned.
+    """
+
+    cfg = getattr(settings, "roll", None)
+    slippage = getattr(cfg, "slippage", 0.05) if cfg else 0.05
+    if days is None:
+        days = getattr(cfg, "default_days", 7) if cfg else 7
+    if weekly is None:
+        weekly = getattr(cfg, "use_weekly", False) if cfg else False
+
+    pos_df = run_with_spinner("Fetching positions…", portfolio_greeks._load_positions)
+    if pos_df.empty:
+        if return_df:
+            return pd.DataFrame()
+        return None
+
+    combos_df = detect_combos(pos_df)
+    if combos_df.empty:
+        if return_df:
+            return pd.DataFrame()
+        return None
+
+    today = dt.date.today()
+    combos_df["expiry"] = pd.to_datetime(combos_df["expiry"]).dt.date
+    mask = combos_df["expiry"] <= today + dt.timedelta(days=days)
+    soon = combos_df[mask]
+    if soon.empty:
+        if return_df:
+            return pd.DataFrame()
+    rows: List[dict] = []
+    for cid, cmb in soon.iterrows():
+        new_exp = _next_expiry(today, weekly)
+        legs = cmb.legs
+        strikes = list(pos_df.loc[legs, "strike"])
+        rights = list(pos_df.loc[legs, "right"])
+        qtys = list(pos_df.loc[legs, "qty"])
+        mult = pos_df.loc[legs, "multiplier"].iloc[0] if "multiplier" in pos_df else 100
+        chain = run_with_spinner(
+            f"Pricing {cmb.underlying}", fetch_chain, cmb.underlying, new_exp, strikes
+        )
+        new_legs = []
+        new_delta = 0.0
+        new_theta = 0.0
+        net_mid = 0.0
+        for strike, right, qty in zip(strikes, rights, qtys):
+            ch = chain[(chain["strike"] == strike) & (chain["right"] == right)].iloc[0]
+            new_legs.append(
+                {
+                    "strike": strike,
+                    "right": right,
+                    "qty": qty,
+                }
+            )
+            new_delta += float(ch.get("delta", 0.0)) * qty
+            new_theta += float(ch.get("theta", 0.0)) * qty
+            net_mid += float(ch.get("mid", 0.0)) * qty
+
+        old_delta = float((pos_df.loc[legs, "delta"] * pos_df.loc[legs, "qty"]).sum())
+        old_theta = float((pos_df.loc[legs, "theta"] * pos_df.loc[legs, "qty"]).sum())
+        debit_credit = net_mid + slippage * sum(qtys)
+        cash_impact = debit_credit * mult
+
+        rows.append(
+            {
+                "combo_id": cid,
+                "underlying": cmb.underlying,
+                "old_exp": cmb.expiry.isoformat(),
+                "new_exp": new_exp,
+                "legs_old": legs,
+                "legs_new": new_legs,
+                "debit_credit": debit_credit,
+                "delta_change": new_delta - old_delta,
+                "theta_change": new_theta - old_theta,
+                "cash_impact": cash_impact,
+                "qty": cmb.qty,
+                "delta_before": old_delta,
+                "delta_after": new_delta,
+                "theta_before": old_theta,
+                "theta_after": new_theta,
+            }
+        )
+
+    df = pd.DataFrame(rows).set_index("combo_id")
+
+    console = Console(force_terminal=True)
+    selected: set = set()
+
+    def _render() -> Table:
+        tbl = Table(show_edge=False)
+        tbl.add_column("*")
+        tbl.add_column("Under")
+        tbl.add_column("Old")
+        tbl.add_column("New")
+        for idx, row in df.iterrows():
+            mark = "*" if idx in selected else ""
+            tbl.add_row(mark, row.underlying, str(row.old_exp), str(row.new_exp))
+        return tbl
+
+    console.print(_render())
+    while True:
+        ch = input()
+        if ch == " ":
+            idx = df.index[0]
+            if idx in selected:
+                selected.remove(idx)
+            else:
+                selected.add(idx)
+        elif ch.lower() == "r":
+            _write_files(df.loc[list(selected)], pos_df)
+        elif ch.lower() == "q":
+            break
+        console.print(_render())
+
+    if return_df:
+        return df
+    return None
+
+
+__all__ = ["run"]

--- a/tests/test_roll_ticket_fields.py
+++ b/tests/test_roll_ticket_fields.py
@@ -1,0 +1,73 @@
+import builtins
+import json
+import datetime as dt
+from pathlib import Path
+
+import pandas as pd
+
+from portfolio_exporter.scripts import roll_manager
+from portfolio_exporter.core.config import settings
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def _prepare(monkeypatch, tmp_path: Path):
+    tomorrow = dt.date.today() + dt.timedelta(days=1)
+    exp = tomorrow.isoformat()
+
+    pos_df = pd.DataFrame(
+        {
+            "underlying": ["XYZ", "XYZ"],
+            "qty": [-1, 1],
+            "right": ["C", "C"],
+            "strike": [100.0, 105.0],
+            "expiry": [exp, exp],
+            "delta": [-0.5, 0.5],
+            "theta": [0.1, -0.1],
+            "multiplier": [100, 100],
+        },
+        index=[1, 2],
+    )
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: pos_df)
+
+    combo_df = pd.DataFrame(
+        {
+            "structure": ["VertCall"],
+            "underlying": ["XYZ"],
+            "expiry": [exp],
+            "qty": [-1],
+            "delta": [0.0],
+            "theta": [0.0],
+            "legs": [[1, 2]],
+        },
+        index=["c1"],
+    )
+    monkeypatch.setattr(roll_manager, "detect_combos", lambda df: combo_df)
+
+    chain_df = pd.DataFrame(
+        [
+            {"strike": 100.0, "right": "C", "mid": 1.0, "delta": 0.2, "theta": -0.02},
+            {"strike": 105.0, "right": "C", "mid": 0.5, "delta": 0.15, "theta": -0.01},
+        ]
+    )
+    monkeypatch.setattr(
+        roll_manager, "fetch_chain", lambda sym, exp, strikes=None: chain_df
+    )
+
+    monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+
+
+def _run(monkeypatch, tmp_path: Path) -> Path:
+    _prepare(monkeypatch, tmp_path)
+    inputs = iter([" ", "r", "q"])
+    monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
+    roll_manager.run()
+    ticket = list(Path(tmp_path).glob("roll_ticket_*.json"))[0]
+    return ticket
+
+
+def test_roll_ticket_fields(monkeypatch, tmp_path):
+    ticket_path = _run(monkeypatch, tmp_path)
+    data = json.loads(ticket_path.read_text())
+    combo = data["combos"][0]
+    assert len(combo["legs_close"]) == 2
+    assert len(combo["legs_open"]) == 2

--- a/tests/test_roll_wizard_logic.py
+++ b/tests/test_roll_wizard_logic.py
@@ -1,0 +1,68 @@
+import builtins
+import datetime as dt
+from pathlib import Path
+
+import pandas as pd
+
+from portfolio_exporter.scripts import roll_manager
+from portfolio_exporter.core.config import settings
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def _setup(monkeypatch, tmp_path: Path):
+    tomorrow = dt.date.today() + dt.timedelta(days=1)
+    exp = tomorrow.isoformat()
+
+    # positions DataFrame indexed by pseudo conIds
+    pos_df = pd.DataFrame(
+        {
+            "underlying": ["XYZ", "XYZ"],
+            "qty": [-1, 1],
+            "right": ["C", "C"],
+            "strike": [100.0, 105.0],
+            "expiry": [exp, exp],
+            "delta": [-0.5, 0.5],
+            "theta": [0.1, -0.1],
+            "multiplier": [100, 100],
+        },
+        index=[1, 2],
+    )
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: pos_df)
+
+    combo_df = pd.DataFrame(
+        {
+            "structure": ["VertCall"],
+            "underlying": ["XYZ"],
+            "expiry": [exp],
+            "qty": [-1],
+            "delta": [0.0],
+            "theta": [0.0],
+            "legs": [[1, 2]],
+        },
+        index=["c1"],
+    )
+    monkeypatch.setattr(roll_manager, "detect_combos", lambda df: combo_df)
+
+    chain_df = pd.DataFrame(
+        [
+            {"strike": 100.0, "right": "C", "mid": 1.0, "delta": 0.2, "theta": -0.02},
+            {"strike": 105.0, "right": "C", "mid": 0.5, "delta": 0.15, "theta": -0.01},
+        ]
+    )
+    monkeypatch.setattr(
+        roll_manager, "fetch_chain", lambda sym, exp, strikes=None: chain_df
+    )
+
+    monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+
+
+def test_roll_wizard_logic(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    inputs = iter([" ", "r", "q"])
+    monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
+    roll_manager.run()
+
+    ticket = list(Path(tmp_path).glob("roll_ticket_*.json"))
+    preview = list(Path(tmp_path).glob("roll_preview_*.csv"))
+    assert ticket, "Ticket JSON not created"
+    assert preview, "Preview CSV not created"


### PR DESCRIPTION
## Summary
- add roll_manager CLI to auto-roll expiring combos and generate tickets + previews
- expose rolling in trade menu
- document roll defaults in settings

## Testing
- `pytest -q`
- `python main.py <<'EOF'
3
l
q
r
0
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68908b7fccd0832eb54b505fcbbb964f