### PR TITLE
feat(builder): live mid-price & Greeks, risk banner, preview CSV

### DIFF
--- a/portfolio_exporter/config/settings.yaml
+++ b/portfolio_exporter/config/settings.yaml
@@ -6,3 +6,8 @@ roll:
   slippage: 0.05           # $0.05 off mid
   default_days: 7
   use_weekly: false
+order_builder:
+  slippage: 0.05
+  delta_cap: 500
+  theta_cap: -100
+  confirm_above_caps: true

--- a/portfolio_exporter/core/ui.py
+++ b/portfolio_exporter/core/ui.py
@@ -109,3 +109,17 @@ def spinner(msg: str):
 def run_with_spinner(msg: str, fn, *a, **kw):
     with spinner(msg):
         return fn(*a, **kw)
+
+
+def banner_delta_theta(
+    delta: float, theta: float, gamma: float, vega: float, cost: float
+) -> None:
+    """Print a colour-coded risk banner."""
+
+    def _c(val: float, fmt: str) -> str:
+        colour = "green" if val >= 0 else "red"
+        return f"[{colour}]{fmt.format(val)}[/{colour}]"
+
+    console.print(
+        f"Δ {_c(delta, '{:+.1f}')}  Θ {_c(theta, '{:+.1f}')}  Γ {_c(gamma, '{:+.3f}')}  Vega {_c(vega, '{:+.1f}')}   Cost {_c(cost, '{:+.2f}')}"
+    )

--- a/tests/test_order_builder.py
+++ b/tests/test_order_builder.py
@@ -9,6 +9,25 @@ def test_order_builder_creates_file(monkeypatch, tmp_path):
     answers = iter(["AAPL 150c 2099-01-01 x2", "", "", "", "", ""])
     monkeypatch.setattr(builtins, "input", lambda _="": next(answers))
     monkeypatch.setattr(builtins, "prompt_toolkit.prompt", lambda x, **k: next(answers))
+    monkeypatch.setattr(
+        order_builder,
+        "quote_option",
+        lambda *a, **k: {
+            "mid": 1.0,
+            "bid": 0.9,
+            "ask": 1.1,
+            "delta": 0.5,
+            "gamma": 0.1,
+            "theta": -0.02,
+            "vega": 0.2,
+            "iv": 0.3,
+        },
+    )
+    monkeypatch.setattr(
+        order_builder,
+        "quote_stock",
+        lambda *a, **k: {"mid": 100.0, "bid": 99.0, "ask": 101.0},
+    )
     order_builder.run()
     tickets = list((tmp_path / "tickets").glob("ticket_*.json"))
     assert tickets, "No ticket file created"

--- a/tests/test_order_builder_caps.py
+++ b/tests/test_order_builder_caps.py
@@ -1,0 +1,42 @@
+import builtins
+import types
+
+from portfolio_exporter.scripts import order_builder
+from portfolio_exporter.core.config import settings
+
+
+def test_order_builder_caps(monkeypatch, tmp_path):
+    cfg = types.SimpleNamespace(
+        slippage=0.05, delta_cap=0, theta_cap=0, confirm_above_caps=True
+    )
+    object.__setattr__(settings, "order_builder", cfg)
+    monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+
+    def fake_quote_option(*args, **kwargs):
+        return {
+            "mid": 1.0,
+            "bid": 0.9,
+            "ask": 1.1,
+            "delta": 0.0,
+            "gamma": 0.0,
+            "theta": -1.0,
+            "vega": 0.0,
+            "iv": 0.2,
+        }
+
+    def fake_quote_stock(*args, **kwargs):
+        return {"mid": 100.0, "bid": 99.0, "ask": 101.0}
+
+    monkeypatch.setattr(order_builder, "quote_option", fake_quote_option)
+    monkeypatch.setattr(order_builder, "quote_stock", fake_quote_stock)
+
+    inputs = iter(["AAPL 150c 2099-01-01 x2", "N"])
+    monkeypatch.setattr(builtins, "input", lambda _="": next(inputs))
+    prompts = iter(["", ""])
+    monkeypatch.setattr(
+        builtins, "prompt_toolkit.prompt", lambda *a, **k: next(prompts)
+    )
+
+    assert order_builder.run() is False
+    tickets = list((tmp_path / "tickets").glob("ticket_*.json"))
+    assert not tickets

--- a/tests/test_order_builder_pricing.py
+++ b/tests/test_order_builder_pricing.py
@@ -1,0 +1,51 @@
+import builtins
+import json
+import pathlib
+import types
+
+from portfolio_exporter.scripts import order_builder
+from portfolio_exporter.core.config import settings
+
+
+def test_order_builder_pricing(monkeypatch, tmp_path):
+    cfg = types.SimpleNamespace(
+        slippage=0.05, delta_cap=500, theta_cap=-100, confirm_above_caps=True
+    )
+    object.__setattr__(settings, "order_builder", cfg)
+    monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+
+    def fake_quote_option(*args, **kwargs):
+        return {
+            "mid": 1.0,
+            "bid": 0.9,
+            "ask": 1.1,
+            "delta": 0.5,
+            "gamma": 0.1,
+            "theta": -0.02,
+            "vega": 0.2,
+            "iv": 0.3,
+        }
+
+    def fake_quote_stock(*args, **kwargs):
+        return {"mid": 100.0, "bid": 99.0, "ask": 101.0}
+
+    monkeypatch.setattr(order_builder, "quote_option", fake_quote_option)
+    monkeypatch.setattr(order_builder, "quote_stock", fake_quote_stock)
+
+    inputs = iter(["AAPL 150c 2099-01-01 x2", "y"])
+    monkeypatch.setattr(builtins, "input", lambda _="": next(inputs))
+    prompts = iter(["", ""])
+    monkeypatch.setattr(
+        builtins, "prompt_toolkit.prompt", lambda *a, **k: next(prompts)
+    )
+
+    assert order_builder.run() is True
+
+    previews = list(tmp_path.glob("order_preview_*.csv"))
+    assert previews, "preview CSV not created"
+
+    tickets = list((tmp_path / "tickets").glob("ticket_*.json"))
+    assert tickets, "ticket JSON not written"
+    data = json.loads(tickets[0].read_text())
+    assert isinstance(data.get("mid_prices"), list)
+    assert "net_delta" in data and "net_theta" in data


### PR DESCRIPTION
## Summary
- price each order leg using IB or stock quotes and compute Greeks and totals
- display color-coded risk banner and gate orders behind delta/theta caps
- record mid prices and risk metrics in ticket JSON with preview CSV output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68909dbb7e14832ebad391ce96845fc6