### PR TITLE
feat(combo v2): add calendars, condors, butterflies and roll lineage

### DIFF
--- a/docs/PDR.md
+++ b/docs/PDR.md
@@ -23,3 +23,11 @@ This document outlines the goals of the project and provides a high level overvi
 
 These scripts share a common approach: IBKR is queried first for portfolio aware data; if connectivity is not available or the ticker is unsupported, they use public APIs such as yfinance. This makes the tools useful even without a running IBKR gateway.
 
+## Combo Types
+
+The combo engine groups option legs into logical strategies.  *Simple* combos
+include vertical spreads and straddles.  The extended engine recognises
+calendars (two legs across expiries), iron condors (four legs) and butterflies
+(three legs).  Each combo stores metadata such as width and roll lineage to
+track related positions over time.
+

--- a/portfolio_exporter/core/combo.py
+++ b/portfolio_exporter/core/combo.py
@@ -7,6 +7,8 @@ import pathlib
 import sqlite3
 from typing import Dict, List
 
+from .io import migrate_combo_schema
+
 import pandas as pd
 
 log = logging.getLogger(__name__)
@@ -22,7 +24,12 @@ CREATE TABLE IF NOT EXISTS combos (
     ts_closed TEXT,
     structure TEXT,
     underlying TEXT,
-    expiry TEXT
+    expiry TEXT,
+    type TEXT,
+    width REAL,
+    credit_debit REAL,
+    parent_combo_id TEXT,
+    closed_date TEXT
 );
 CREATE TABLE IF NOT EXISTS legs (
     combo_id TEXT,
@@ -37,6 +44,7 @@ CREATE TABLE IF NOT EXISTS legs (
 def _db() -> sqlite3.Connection:
     conn = sqlite3.connect(DB_PATH)
     conn.executescript(_DDL)
+    migrate_combo_schema(conn)
     return conn
 
 
@@ -49,7 +57,7 @@ def _hash_combo(conids: List[int]) -> str:
 
 
 # ---------- public API ----------------------------------------------------
-def detect_combos(pos_df: pd.DataFrame) -> pd.DataFrame:
+def detect_combos(pos_df: pd.DataFrame, mode: str = "all") -> pd.DataFrame:
     """Group legs into combos and persist mapping.
 
     ``pos_df`` must be indexed by ``conId`` and include the following columns:
@@ -57,47 +65,54 @@ def detect_combos(pos_df: pd.DataFrame) -> pd.DataFrame:
     ``delta``, ``gamma``, ``vega`` and ``theta``.
 
     Returns a DataFrame with one row per combo summarising the greeks and
-    including the list of legs.
+    including the list of legs.  ``mode`` may be ``"simple"`` to only detect
+    verticals and straddles or ``"all"`` to include calendars, condors and
+    butterflies.
     """
 
-    # guarantee the column is present (stock legs will have <NA>)
     if "right" not in pos_df.columns:
         pos_df["right"] = pd.NA
 
     combos: List[Dict] = []
     used: set[int] = set()
 
-    # 1) try to match verticals
-    for idx, leg in pos_df.iterrows():
-        if idx in used or leg["right"] not in {"C", "P"}:
-            continue
-        opp = pos_df[
-            (pos_df["underlying"] == leg["underlying"])
-            & (pos_df["expiry"] == leg["expiry"])
-            & (pos_df["right"] == leg["right"])
-            & (pos_df["qty"] == -leg["qty"])
-        ]
-        opp = opp[opp.index != idx]  # exclude itself
-        if len(opp) == 1:
-            other = opp.iloc[0]
-            legs_idx = [idx, other.name]
-            used.update(legs_idx)
-            combos.append(
-                _row(
-                    "VertCall" if leg["right"] == "C" else "VertPut",
-                    pos_df.loc[legs_idx],
+    for _, sub in pos_df.groupby("underlying"):
+        if mode == "all":
+            combos.extend(_match_calendar(sub, used))
+            combos.extend(_match_condor(sub, used))
+            combos.extend(_match_butterfly(sub, used))
+
+        # verticals
+        for idx, leg in sub.iterrows():
+            if idx in used or leg["right"] not in {"C", "P"}:
+                continue
+            opp = sub[
+                (sub["expiry"] == leg["expiry"])
+                & (sub["right"] == leg["right"])
+                & (sub["qty"] == -leg["qty"])
+            ]
+            opp = opp[opp.index != idx]
+            if len(opp) == 1:
+                other = opp.iloc[0]
+                legs_idx = [idx, other.name]
+                used.update(legs_idx)
+                width = _calc_width(pos_df.loc[legs_idx])
+                combos.append(
+                    _row(
+                        "VertCall" if leg["right"] == "C" else "VertPut",
+                        pos_df.loc[legs_idx],
+                        "vertical",
+                        width,
+                    )
                 )
-            )
-            continue
 
-    # 2) single straddles (buy or sell)
-    for conids in _pair_same_strike(pos_df, used):
-        used.update(conids)
-        combos.append(_row("Straddle", pos_df.loc[conids]))
+        # straddles
+        for conids in _pair_same_strike(sub, used):
+            used.update(conids)
+            combos.append(_row("Straddle", pos_df.loc[conids], "straddle", 0.0))
 
-    # 3) group leftover singles
     for idx in pos_df.index.difference(used):
-        combos.append(_row("Single", pos_df.loc[[idx]]))
+        combos.append(_row("Single", pos_df.loc[[idx]], "single"))
 
     combo_df = pd.DataFrame(combos)
     if combo_df.empty:
@@ -112,6 +127,11 @@ def detect_combos(pos_df: pd.DataFrame) -> pd.DataFrame:
                 "gamma",
                 "vega",
                 "theta",
+                "type",
+                "width",
+                "credit_debit",
+                "parent_combo_id",
+                "closed_date",
                 "legs",
             ]
         ).set_index("combo_id")
@@ -122,7 +142,13 @@ def detect_combos(pos_df: pd.DataFrame) -> pd.DataFrame:
 
 
 # ---------- helpers -------------------------------------------------------
-def _row(structure: str, legs_df: pd.DataFrame) -> Dict:
+def _row(
+    structure: str,
+    legs_df: pd.DataFrame,
+    type_: str,
+    width: float | None = None,
+    credit_debit: float | None = None,
+) -> Dict:
     combo_id = _hash_combo(list(legs_df.index))
     return dict(
         combo_id=combo_id,
@@ -134,8 +160,65 @@ def _row(structure: str, legs_df: pd.DataFrame) -> Dict:
         gamma=legs_df["gamma"].sum(),
         vega=legs_df["vega"].sum(),
         theta=legs_df["theta"].sum(),
+        type=type_,
+        width=width,
+        credit_debit=credit_debit,
+        parent_combo_id=None,
+        closed_date=None,
         legs=list(legs_df.index),
     )
+
+
+def _calc_width(legs_df: pd.DataFrame) -> float | None:
+    strikes = sorted(set(legs_df["strike"]))
+    if len(strikes) <= 1:
+        return 0.0
+    diffs = [b - a for a, b in zip(strikes[:-1], strikes[1:])]
+    return min(diffs) if diffs else 0.0
+
+
+def _match_calendar(df: pd.DataFrame, used: set[int]) -> List[Dict]:
+    combos: List[Dict] = []
+    sub = df[~df.index.isin(used)]
+    for (strike, right), grp in sub.groupby(["strike", "right"]):
+        if len(grp) == 2 and grp["expiry"].nunique() == 2:
+            q0, q1 = grp["qty"].iloc[0], grp["qty"].iloc[1]
+            if q0 == -q1:
+                conids = list(grp.index)
+                used.update(conids)
+                combos.append(_row("Calendar", df.loc[conids], "calendar", 0.0))
+    return combos
+
+
+def _match_condor(df: pd.DataFrame, used: set[int]) -> List[Dict]:
+    combos: List[Dict] = []
+    sub = df[~df.index.isin(used)]
+    for exp, grp in sub.groupby("expiry"):
+        calls = grp[grp["right"] == "C"]
+        puts = grp[grp["right"] == "P"]
+        if len(calls) == 2 and len(puts) == 2:
+            if {1, -1} <= set(calls["qty"]) and {1, -1} <= set(puts["qty"]):
+                conids = list(calls.index) + list(puts.index)
+                used.update(conids)
+                width = _calc_width(df.loc[conids])
+                combos.append(_row("Condor", df.loc[conids], "condor", width))
+    return combos
+
+
+def _match_butterfly(df: pd.DataFrame, used: set[int]) -> List[Dict]:
+    combos: List[Dict] = []
+    sub = df[~df.index.isin(used)]
+    for (exp, right), grp in sub.groupby(["expiry", "right"]):
+        if len(grp) == 3:
+            qtys = list(grp["qty"])
+            if (qtys.count(-2) == 1 and qtys.count(1) == 2) or (
+                qtys.count(2) == 1 and qtys.count(-1) == 2
+            ):
+                conids = list(grp.index)
+                used.update(conids)
+                width = _calc_width(df.loc[conids])
+                combos.append(_row("Butterfly", df.loc[conids], "butterfly", width))
+    return combos
 
 
 def _pair_same_strike(df: pd.DataFrame, used: set[int]) -> List[List[int]]:
@@ -151,19 +234,64 @@ def _pair_same_strike(df: pd.DataFrame, used: set[int]) -> List[List[int]]:
 def _sync_with_db(combo_df: pd.DataFrame, pos_df: pd.DataFrame) -> None:
     conn = _db()
     now = _dt.datetime.utcnow().isoformat(timespec="seconds")
+    today = _dt.date.today().isoformat()
 
-    # mark inactive combo_ids as closed
     active = set(combo_df.index)
+    cur = conn.execute(
+        "SELECT combo_id, underlying, expiry, structure FROM combos WHERE ts_closed IS NULL"
+    )
+    open_combos = {}
+    for cid, underlying, expiry, structure in cur.fetchall():
+        legs = conn.execute(
+            "SELECT strike, right FROM legs WHERE combo_id=?", (cid,)
+        ).fetchall()
+        open_combos[cid] = {
+            "underlying": underlying,
+            "expiry": expiry,
+            "structure": structure,
+            "legs": sorted(legs),
+        }
+
+    parent_map: Dict[str, str] = {}
+    for cid, row in combo_df.iterrows():
+        key = sorted([(pos_df.loc[l].strike, pos_df.loc[l].right) for l in row.legs])
+        for ocid, data in open_combos.items():
+            if (
+                data["underlying"] == row.underlying
+                and data["structure"] == row.structure
+                and data["legs"] == key
+                and data["expiry"] != row.expiry
+            ):
+                parent_map[cid] = ocid
+                break
+
+    rolled_parents = set(parent_map.values())
+
     cur = conn.execute("SELECT combo_id, ts_closed FROM combos")
     for cid, ts_closed in cur.fetchall():
         if cid not in active and ts_closed is None:
-            conn.execute("UPDATE combos SET ts_closed=? WHERE combo_id=?", (now, cid))
+            closed_date = today if cid in rolled_parents else None
+            conn.execute(
+                "UPDATE combos SET ts_closed=?, closed_date=? WHERE combo_id=?",
+                (now, closed_date, cid),
+            )
 
-    # upsert active combos and legs
     for cid, row in combo_df.iterrows():
         conn.execute(
-            "INSERT OR IGNORE INTO combos VALUES (?,?,?,?,?,?)",
-            (cid, now, None, row.structure, row.underlying, row.expiry),
+            "INSERT OR IGNORE INTO combos (combo_id, ts_created, ts_closed, structure, underlying, expiry, type, width, credit_debit, parent_combo_id, closed_date) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                cid,
+                now,
+                None,
+                row.structure,
+                row.underlying,
+                row.expiry,
+                row.get("type"),
+                row.get("width"),
+                row.get("credit_debit"),
+                parent_map.get(cid),
+                None,
+            ),
         )
         for conid in row.legs:
             leg = pos_df.loc[conid]
@@ -173,6 +301,8 @@ def _sync_with_db(combo_df: pd.DataFrame, pos_df: pd.DataFrame) -> None:
             )
 
     conn.commit()
+    for cid, parent in parent_map.items():
+        combo_df.loc[cid, "parent_combo_id"] = parent
 
 
 def fetch_persisted_mapping() -> Dict[int, str]:

--- a/portfolio_exporter/scripts/portfolio_greeks.py
+++ b/portfolio_exporter/scripts/portfolio_greeks.py
@@ -1037,6 +1037,7 @@ def run(
     write_totals: bool = True,
     return_dict: bool = False,
     combos: bool = True,
+    combo_types: str = "simple",
 ) -> dict | None:
     """Aggregate per-position Greeks and optionally persist the results."""
 
@@ -1067,7 +1068,7 @@ def run(
     for greek in ["delta", "gamma", "vega", "theta"]:
         pos_df[f"{greek}_exposure"] = pos_df[greek] * pos_df.qty * pos_df.multiplier
 
-    combos_df = detect_combos(pos_df) if combos else pd.DataFrame()
+    combos_df = detect_combos(pos_df, mode=combo_types) if combos else pd.DataFrame()
 
     totals = (
         pos_df[[f"{g}_exposure" for g in ["delta", "gamma", "vega", "theta"]]]
@@ -1109,5 +1110,15 @@ if __name__ == "__main__":  # pragma: no cover - CLI entry
     parser.add_argument(
         "--no-combos", action="store_true", help="Disable combo detection"
     )
+    parser.add_argument(
+        "--combo-types",
+        choices=["simple", "all"],
+        default="simple",
+        help="Combo detection complexity",
+    )
     args = parser.parse_args()
-    run(fmt=args.fmt, combos=not args.no_combos)
+    run(
+        fmt=args.fmt,
+        combos=not args.no_combos,
+        combo_types=args.combo_types,
+    )

--- a/portfolio_exporter/scripts/roll_manager.py
+++ b/portfolio_exporter/scripts/roll_manager.py
@@ -11,6 +11,7 @@ rest of the project while remaining easy to stub in tests.
 
 from __future__ import annotations
 
+import argparse
 import calendar
 import datetime as dt
 import json
@@ -118,6 +119,7 @@ def run(
     weekly: bool | None = None,
     fmt: str = "csv",
     return_df: bool = False,
+    include_cal: bool = False,
 ):
     """Interactive roll manager.
 
@@ -150,6 +152,8 @@ def run(
         return None
 
     combos_df = detect_combos(pos_df)
+    if not include_cal and "type" in combos_df.columns:
+        combos_df = combos_df[combos_df["type"] != "calendar"]
     if combos_df.empty:
         if return_df:
             return pd.DataFrame()
@@ -272,6 +276,13 @@ def run(
     if return_df:
         return df
     return None
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Roll manager")
+    parser.add_argument("--include-cal", action="store_true", help="Include calendars")
+    args = parser.parse_args()
+    run(include_cal=args.include_cal)
 
 
 __all__ = ["run"]

--- a/tests/test_combo_butterfly.py
+++ b/tests/test_combo_butterfly.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+from portfolio_exporter.core import combo
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def test_combo_butterfly(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "underlying": "XYZ",
+                "qty": 1,
+                "right": "C",
+                "strike": 95.0,
+                "expiry": "20240119",
+                "delta": 0.0,
+                "gamma": 0.0,
+                "vega": 0.0,
+                "theta": 0.0,
+            },
+            {
+                "underlying": "XYZ",
+                "qty": -2,
+                "right": "C",
+                "strike": 100.0,
+                "expiry": "20240119",
+                "delta": 0.0,
+                "gamma": 0.0,
+                "vega": 0.0,
+                "theta": 0.0,
+            },
+            {
+                "underlying": "XYZ",
+                "qty": 1,
+                "right": "C",
+                "strike": 105.0,
+                "expiry": "20240119",
+                "delta": 0.0,
+                "gamma": 0.0,
+                "vega": 0.0,
+                "theta": 0.0,
+            },
+        ],
+        index=[1, 2, 3],
+    )
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: df)
+    combos = combo.detect_combos(portfolio_greeks._load_positions(), mode="all")
+    assert len(combos) == 1
+    fly = combos.iloc[0]
+    assert fly.structure == "Butterfly"
+    assert fly.type == "butterfly"
+    assert fly.width == 5.0

--- a/tests/test_combo_calendar.py
+++ b/tests/test_combo_calendar.py
@@ -1,0 +1,41 @@
+import pandas as pd
+
+from portfolio_exporter.core import combo
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def test_combo_calendar(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "underlying": "XYZ",
+                "qty": 1,
+                "right": "C",
+                "strike": 100.0,
+                "expiry": "20240119",
+                "delta": 0.5,
+                "gamma": 0.1,
+                "vega": 0.2,
+                "theta": -0.05,
+            },
+            {
+                "underlying": "XYZ",
+                "qty": -1,
+                "right": "C",
+                "strike": 100.0,
+                "expiry": "20240216",
+                "delta": -0.4,
+                "gamma": -0.08,
+                "vega": -0.15,
+                "theta": 0.04,
+            },
+        ],
+        index=[1, 2],
+    )
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: df)
+    combos = combo.detect_combos(portfolio_greeks._load_positions(), mode="all")
+    assert len(combos) == 1
+    cal = combos.iloc[0]
+    assert cal.structure == "Calendar"
+    assert cal.type == "calendar"
+    assert cal.width == 0.0

--- a/tests/test_combo_condor.py
+++ b/tests/test_combo_condor.py
@@ -1,0 +1,63 @@
+import pandas as pd
+
+from portfolio_exporter.core import combo
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def test_combo_condor(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "underlying": "XYZ",
+                "qty": 1,
+                "right": "P",
+                "strike": 95.0,
+                "expiry": "20240119",
+                "delta": 0.0,
+                "gamma": 0.0,
+                "vega": 0.0,
+                "theta": 0.0,
+            },
+            {
+                "underlying": "XYZ",
+                "qty": -1,
+                "right": "P",
+                "strike": 100.0,
+                "expiry": "20240119",
+                "delta": 0.0,
+                "gamma": 0.0,
+                "vega": 0.0,
+                "theta": 0.0,
+            },
+            {
+                "underlying": "XYZ",
+                "qty": -1,
+                "right": "C",
+                "strike": 110.0,
+                "expiry": "20240119",
+                "delta": 0.0,
+                "gamma": 0.0,
+                "vega": 0.0,
+                "theta": 0.0,
+            },
+            {
+                "underlying": "XYZ",
+                "qty": 1,
+                "right": "C",
+                "strike": 115.0,
+                "expiry": "20240119",
+                "delta": 0.0,
+                "gamma": 0.0,
+                "vega": 0.0,
+                "theta": 0.0,
+            },
+        ],
+        index=[1, 2, 3, 4],
+    )
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: df)
+    combos = combo.detect_combos(portfolio_greeks._load_positions(), mode="all")
+    assert len(combos) == 1
+    condor = combos.iloc[0]
+    assert condor.structure == "Condor"
+    assert condor.type == "condor"
+    assert condor.width == 5.0

--- a/tests/test_roll_lineage.py
+++ b/tests/test_roll_lineage.py
@@ -1,0 +1,58 @@
+import sqlite3
+import pandas as pd
+
+from portfolio_exporter.core import combo
+from portfolio_exporter.scripts import portfolio_greeks
+
+
+def test_roll_lineage(tmp_path, monkeypatch):
+    db_path = tmp_path / "combos.db"
+    monkeypatch.setattr(combo, "DB_PATH", db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    df1 = pd.DataFrame(
+        [
+            {
+                "underlying": "XYZ",
+                "qty": -1,
+                "right": "C",
+                "strike": 100.0,
+                "expiry": "20240119",
+                "delta": -0.5,
+                "gamma": -0.1,
+                "vega": -0.2,
+                "theta": 0.05,
+            },
+            {
+                "underlying": "XYZ",
+                "qty": 1,
+                "right": "C",
+                "strike": 105.0,
+                "expiry": "20240119",
+                "delta": 0.4,
+                "gamma": 0.08,
+                "vega": 0.15,
+                "theta": -0.04,
+            },
+        ],
+        index=[1, 2],
+    )
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: df1)
+    combos1 = combo.detect_combos(portfolio_greeks._load_positions(), mode="all")
+    parent_id = combos1.index[0]
+
+    df2 = df1.copy()
+    df2["expiry"] = "20240216"
+    df2.index = [3, 4]
+    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: df2)
+    combos2 = combo.detect_combos(portfolio_greeks._load_positions(), mode="all")
+    child_id = combos2.index[0]
+
+    assert combos2.loc[child_id, "parent_combo_id"] == parent_id
+
+    conn = sqlite3.connect(db_path)
+    closed = conn.execute(
+        "SELECT closed_date FROM combos WHERE combo_id=?", (parent_id,)
+    ).fetchone()[0]
+    conn.close()
+    assert closed is not None


### PR DESCRIPTION
## Summary
- expand combo engine with calendar, condor and butterfly detection and track roll lineage in SQLite
- migrate combo schema with new fields and expose combo type filtering in greeks and roll scripts
- document supported combo types and add tests for new combos and roll lineage

## Testing
- `pytest -q`
- `PE_TEST_MODE=1 python -m portfolio_exporter.scripts.portfolio_greeks`


------
https://chatgpt.com/codex/tasks/task_e_6893784a8540832eb11520cc0304c4a1