### PR TITLE
feat: live combo fallback for Greeks preview

### DIFF
--- a/portfolio_exporter/core/combo.py
+++ b/portfolio_exporter/core/combo.py
@@ -173,6 +173,30 @@ def detect_combos(pos_df: pd.DataFrame, mode: str = "all") -> pd.DataFrame:
     return combo_df
 
 
+def detect_from_positions(df_positions: pd.DataFrame) -> pd.DataFrame:
+    """
+    Use existing v2 combo engine to cluster legs into combos from a positions DF.
+    Return columns at least: ['structure','underlying','expiry','qty','width','type','legs']
+    (re-use existing internal functions; this is a thin wrapper)
+    """
+
+    combo_df = detect_combos(df_positions, mode="all")
+    cols = [
+        c
+        for c in [
+            "structure",
+            "underlying",
+            "expiry",
+            "qty",
+            "width",
+            "type",
+            "legs",
+        ]
+        if c in combo_df.columns
+    ]
+    return combo_df[cols]
+
+
 # ---------- helpers -------------------------------------------------------
 def _row(
     structure: str,


### PR DESCRIPTION
## Summary
- load combo metadata from database with heuristics
- fall back to live combo detection for pretty display
- expose `detect_from_positions` helper in combo module

## Testing
- `ruff check portfolio_exporter/core/combo.py portfolio_exporter/scripts/portfolio_greeks.py`
- `pytest tests/test_portfolio_greeks.py -q` *(fails: ModuleNotFoundError: No module named 'yfinance')*
- `PYTHONPATH=. PE_TEST_MODE=1 python portfolio_exporter/scripts/portfolio_greeks.py --combo-types all` *(fails: ModuleNotFoundError: No module named 'ib_insync')*

------
https://chatgpt.com/codex/tasks/task_e_68972e65a21c832e95528a2db9705ed2