### PR TITLE
Add Roll Manager CLI with JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ python option_chain_snapshot.py --symbol-expiries 'TSLA:20250620,20250703;AAPL:2
 # Export today's executions and open orders
 python trades_report.py --today
 
+### Roll Manager CLI
+
+```bash
+python -m portfolio_exporter.scripts.roll_manager --days 28 --tenor monthly --no-pretty
+python -m portfolio_exporter.scripts.roll_manager --json
+```
+
 ### Trades Report
 
 Examples with date filters and summaries:

--- a/tests/test_roll_manager_cli.py
+++ b/tests/test_roll_manager_cli.py
@@ -1,0 +1,48 @@
+import argparse
+import types
+import argparse
+import types
+import importlib.util
+import pathlib
+import pandas as pd
+
+spec = importlib.util.spec_from_file_location(
+    "roll_manager",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "portfolio_exporter/scripts/roll_manager.py",
+)
+roll_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(roll_manager)
+
+
+def _stub_positions():
+    return pd.DataFrame()
+
+
+def _stub_spinner(msg, fn, *a, **k):
+    return fn(*a, **k)
+
+
+def test_run_returns_df(monkeypatch):
+    fake_pg = types.SimpleNamespace(_load_positions=_stub_positions)
+    monkeypatch.setattr(roll_manager, "portfolio_greeks", fake_pg)
+    monkeypatch.setattr(roll_manager, "run_with_spinner", _stub_spinner)
+    df = roll_manager.run(return_df=True)
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_cli_json(monkeypatch):
+    fake_pg = types.SimpleNamespace(_load_positions=_stub_positions)
+    monkeypatch.setattr(roll_manager, "portfolio_greeks", fake_pg)
+    monkeypatch.setattr(roll_manager, "run_with_spinner", _stub_spinner)
+    ns = argparse.Namespace(
+        include_cal=False,
+        days=7,
+        tenor="all",
+        no_pretty=True,
+        json=True,
+        output_dir=None,
+    )
+    summary = roll_manager.cli(ns)
+    for key in ["n_candidates", "n_selected", "underlyings", "by_structure", "outputs"]:
+        assert key in summary

--- a/tests/test_roll_ticket_fields.py
+++ b/tests/test_roll_ticket_fields.py
@@ -2,12 +2,18 @@ import builtins
 import json
 import datetime as dt
 from pathlib import Path
-
+import importlib.util
+import pathlib
+import types
 import pandas as pd
 
-from portfolio_exporter.scripts import roll_manager
+spec = importlib.util.spec_from_file_location(
+    "roll_manager",
+    pathlib.Path(__file__).resolve().parents[1] / "portfolio_exporter/scripts/roll_manager.py",
+)
+roll_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(roll_manager)
 from portfolio_exporter.core.config import settings
-from portfolio_exporter.scripts import portfolio_greeks
 
 
 def _prepare(monkeypatch, tmp_path: Path):
@@ -27,7 +33,8 @@ def _prepare(monkeypatch, tmp_path: Path):
         },
         index=[1, 2],
     )
-    monkeypatch.setattr(portfolio_greeks, "_load_positions", lambda: pos_df)
+    fake_pg = types.SimpleNamespace(_load_positions=lambda: pos_df)
+    monkeypatch.setattr(roll_manager, "portfolio_greeks", fake_pg)
 
     combo_df = pd.DataFrame(
         {
@@ -49,9 +56,7 @@ def _prepare(monkeypatch, tmp_path: Path):
             {"strike": 105.0, "right": "C", "mid": 0.5, "delta": 0.15, "theta": -0.01},
         ]
     )
-    monkeypatch.setattr(
-        roll_manager, "fetch_chain", lambda sym, exp, strikes=None: chain_df
-    )
+    monkeypatch.setattr(roll_manager, "fetch_chain", lambda sym, exp, strikes=None: chain_df)
 
     monkeypatch.setattr(settings, "output_dir", str(tmp_path))
 


### PR DESCRIPTION
## Summary
- add argparse entrypoint for roll_manager with JSON summary, tenor filtering, and quiet mode
- support json saving via core.io.save and route roll_manager outputs through it
- document and test roll_manager CLI

## Testing
- `ruff check portfolio_exporter/scripts/roll_manager.py portfolio_exporter/core/io.py tests/test_roll_manager_cli.py tests/test_roll_ticket_fields.py tests/test_roll_wizard_logic.py`
- `pytest tests/test_roll_manager_cli.py tests/test_roll_ticket_fields.py tests/test_roll_wizard_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0eee8640832e86caf4e953255ddb