### PR TITLE
Add JSON summary and output-dir override to quick-chain CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,12 +233,33 @@ python -m portfolio_exporter.scripts.quick_chain --symbols SPY --target-delta 0.
 
 # Offline fixture (no network)
 python -m portfolio_exporter.scripts.quick_chain --chain-csv tests/data/quick_chain_fixture.csv --target-delta 0.30 --side put --tenor weekly
+
+# Override output directory
+python -m portfolio_exporter.scripts.quick_chain --chain-csv tests/data/quick_chain_fixture.csv --output-dir /tmp
+
+# JSON summary (no files written)
+python -m portfolio_exporter.scripts.quick_chain --chain-csv tests/data/quick_chain_fixture.csv --json
 ```
 
 Outputs:
 - CSV: base chain table plus new columns: `call_same_delta_strike`, `call_same_delta_delta`, `call_same_delta_mid`, `call_same_delta_iv`, and corresponding `put_*` fields.
 - HTML: optional minimal table when `--html` is provided.
 - PDF: optional table when `--pdf` is provided and `reportlab` is installed.
+
+JSON summary schema:
+
+```
+{
+  "rows": <int>,
+  "underlyings": [<str>],
+  "tenor": "<value or ''>",
+  "target_delta": <float | null>,
+  "side": "<call|put|both|''>",
+  "outputs": {"csv": "<path or ''>", "html": "<path or ''>", "pdf": "<path or ''>"}
+}
+```
+
+CSV-only runs skip IBKR and Yahoo Finance imports thanks to lazy dependencies.
 
 ## Contributing
 

--- a/portfolio_exporter/core/io.py
+++ b/portfolio_exporter/core/io.py
@@ -11,7 +11,7 @@ def save(
     # Default to configured output directory when not explicitly provided
     outdir = Path(outdir or settings.output_dir).expanduser()
     outdir.mkdir(parents=True, exist_ok=True)
-    ext_map = {"csv": "csv", "excel": "xlsx", "pdf": "pdf", "json": "json"}
+    ext_map = {"csv": "csv", "excel": "xlsx", "pdf": "pdf", "json": "json", "html": "html"}
     fname = outdir / f"{name}.{ext_map[fmt]}"
     if fmt == "csv":
         assert isinstance(obj, pd.DataFrame)
@@ -19,6 +19,9 @@ def save(
     elif fmt == "excel":
         assert isinstance(obj, pd.DataFrame)
         obj.to_excel(fname, index=False)
+    elif fmt == "html":
+        assert isinstance(obj, pd.DataFrame)
+        obj.to_html(fname, index=False)
     elif fmt == "pdf":
         import reportlab  # noqa: F401 – ensure dep
 

--- a/portfolio_exporter/scripts/__init__.py
+++ b/portfolio_exporter/scripts/__init__.py
@@ -1,22 +1,3 @@
-from . import (
-    update_tickers,
-    historic_prices,
-    daily_pulse,
-    option_chain_snapshot,
-    net_liq_history_export,
-    orchestrate_dataset,
-    tech_scan,
-    live_feed,
-    tech_signals_ibkr,
-    portfolio_greeks,
-    risk_watch,
-    theta_cap,
-    gamma_scalp,
-    trades_report,
-    order_builder,
-    roll_manager,
-)
-
 __all__ = [
     "update_tickers",
     "historic_prices",
@@ -34,4 +15,5 @@ __all__ = [
     "trades_report",
     "order_builder",
     "roll_manager",
+    "quick_chain",
 ]

--- a/tests/data/quick_chain_fixture.csv
+++ b/tests/data/quick_chain_fixture.csv
@@ -1,0 +1,3 @@
+underlying,expiry,right,strike,mid,delta,iv
+TEST,2099-01-01,C,100,1.0,0.3,0.2
+TEST,2099-01-01,P,100,1.1,-0.3,0.2

--- a/tests/test_quick_chain_cli.py
+++ b/tests/test_quick_chain_cli.py
@@ -1,0 +1,75 @@
+import json
+import os
+import subprocess
+import sys
+import importlib
+
+
+def test_json_summary_no_files(tmp_path):
+    env = os.environ.copy()
+    env.update({
+        "PYTHONPATH": ".",
+        "PE_TEST_MODE": "1",
+        "PE_OUTPUT_DIR": str(tmp_path),
+    })
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/quick_chain.py",
+            "--chain-csv",
+            "tests/data/quick_chain_fixture.csv",
+            "--no-pretty",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout)
+    assert data["rows"] > 0
+    assert data["underlyings"]
+    assert not any(tmp_path.iterdir())
+
+
+def test_output_dir_override(tmp_path):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1"})
+    subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/quick_chain.py",
+            "--chain-csv",
+            "tests/data/quick_chain_fixture.csv",
+            "--output-dir",
+            str(tmp_path),
+        ],
+        check=True,
+        env=env,
+    )
+    assert (tmp_path / "quick_chain.csv").exists()
+
+
+def test_lazy_deps(monkeypatch, tmp_path, capsys):
+    monkeypatch.setitem(sys.modules, "ib_insync", None)
+    monkeypatch.setenv("PE_TEST_MODE", "1")
+    monkeypatch.setenv("PE_OUTPUT_DIR", str(tmp_path))
+    if "portfolio_exporter.scripts.quick_chain" in sys.modules:
+        del sys.modules["portfolio_exporter.scripts.quick_chain"]
+    qc = importlib.import_module("portfolio_exporter.scripts.quick_chain")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "quick_chain",
+            "--chain-csv",
+            "tests/data/quick_chain_fixture.csv",
+            "--json",
+        ],
+    )
+    code = qc._run_cli_v3()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert code == 0
+    assert data["rows"] > 0
+    assert not any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- extend `quick_chain` with `--output-dir` to route outputs and `--json` to emit a compact summary
- lazily import optional deps so CSV-only runs avoid IBKR/Yahoo modules
- document and test new CLI behaviours

## Testing
- `ruff check portfolio_exporter/scripts/quick_chain.py portfolio_exporter/core/io.py portfolio_exporter/scripts/__init__.py tests/test_quick_chain_cli.py`
- `pytest -q tests/test_quick_chain_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689b140b7e0c832eb77d6bc023ce909c