### PR TITLE
Tune order_builder strategy builders to match playbook leg directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,46 @@ JSON summary fields: `n_total`, `n_kept`, `u_count`, `underlyings`, `net_credit_
 
 Open interest values are sourced from Yahoo Finance rather than the IBKR feed.
 
+### Build Order (CLI)
+
+The non-interactive order builder creates normalized ticket JSONs for common strategies.
+Each strategy defaults to the house leg directions; flipping the sign of `--qty`
+switches between credit and debit orientations.
+
+```bash
+# Bull call (debit) vs. bear call (credit)
+python -m portfolio_exporter.scripts.order_builder --strategy vertical --symbol SPY --right C --expiry 2025-06-20 --strikes 400,410 --qty 1
+python -m portfolio_exporter.scripts.order_builder --strategy vertical --symbol SPY --right C --expiry 2025-06-20 --strikes 400,410 --qty -1
+
+# Bull put (credit) vs. bear put (debit)
+python -m portfolio_exporter.scripts.order_builder --strategy vertical --symbol SPY --right P --expiry 2025-06-20 --strikes 390,380 --qty 1
+python -m portfolio_exporter.scripts.order_builder --strategy vertical --symbol SPY --right P --expiry 2025-06-20 --strikes 390,380 --qty -1
+
+# Short vs. long iron condor (strike order auto-sorted)
+python -m portfolio_exporter.scripts.order_builder --strategy iron_condor --symbol SPY --expiry 2025-06-20 --strikes 380,390,410,420 --qty -1
+python -m portfolio_exporter.scripts.order_builder --strategy iron_condor --symbol SPY --expiry 2025-06-20 --strikes 380,390,410,420 --qty 1
+
+# Long vs. short butterfly
+python -m portfolio_exporter.scripts.order_builder --strategy butterfly --symbol SPY --right C --expiry 2025-06-20 --strikes 390,400,410 --qty 1
+python -m portfolio_exporter.scripts.order_builder --strategy butterfly --right C --symbol SPY --expiry 2025-06-20 --strikes 390,400,410 --qty -1
+
+# Long vs. short calendar
+python -m portfolio_exporter.scripts.order_builder --strategy calendar --symbol SPY --right C --strike 400 --expiry-near 2025-05-17 --expiry-far 2025-06-20 --qty 1
+python -m portfolio_exporter.scripts.order_builder --strategy calendar --symbol SPY --right C --strike 400 --expiry-near 2025-05-17 --expiry-far 2025-06-20 --qty -1
+
+# Long vs. short straddle
+python -m portfolio_exporter.scripts.order_builder --strategy straddle --symbol SPY --expiry 2025-06-20 --strike 400 --qty 1
+python -m portfolio_exporter.scripts.order_builder --strategy straddle --symbol SPY --expiry 2025-06-20 --strike 400 --qty -1
+
+# Long vs. short strangle
+python -m portfolio_exporter.scripts.order_builder --strategy strangle --symbol SPY --expiry 2025-06-20 --strikes 390,410 --qty 1
+python -m portfolio_exporter.scripts.order_builder --strategy strangle --symbol SPY --expiry 2025-06-20 --strikes 390,410 --qty -1
+
+# Covered call income vs. buy-write
+python -m portfolio_exporter.scripts.order_builder --strategy covered_call --symbol SPY --expiry 2025-06-20 --call-strike 410 --qty -1
+python -m portfolio_exporter.scripts.order_builder --strategy covered_call --symbol SPY --expiry 2025-06-20 --call-strike 410 --qty 1
+```
+
 ### Expiry hint formats
 
 When prompted for an expiry, you may provide:

--- a/portfolio_exporter/scripts/order_builder.py
+++ b/portfolio_exporter/scripts/order_builder.py
@@ -15,7 +15,10 @@ from yfinance import Ticker
 from portfolio_exporter.core.config import settings
 from portfolio_exporter.core.input import parse_order_line
 from portfolio_exporter.core.ui import banner_delta_theta, console
-from portfolio_exporter.core.ib import quote_option, quote_stock
+try:  # pragma: no cover - ib_insync optional in tests
+    from portfolio_exporter.core.ib import quote_option, quote_stock  # type: ignore
+except Exception:  # pragma: no cover
+    quote_option = quote_stock = None  # type: ignore
 
 # Expose prompt_toolkit.prompt via a dotted builtins attribute for tests
 setattr(builtins, "prompt_toolkit.prompt", prompt)
@@ -59,13 +62,194 @@ def _price_leg(
     symbol: str, expiry: str | None, strike: float | None, right: str | None
 ) -> Dict[str, float]:
     if right in {"C", "P"}:
+        if quote_option is None:
+            raise RuntimeError("quote_option not available")
         # If an expiry was provided, use it as-is to avoid network normalization.
         # Only resolve to the nearest listed expiry when it's missing.
         expiry = expiry or _nearest_expiry(symbol, expiry)
         return quote_option(symbol, expiry or "", float(strike), right)
+    if quote_stock is None:
+        raise RuntimeError("quote_stock not available")
     data = quote_stock(symbol)
     data.update({"delta": 1.0, "gamma": 0.0, "theta": 0.0, "vega": 0.0, "iv": 0.0})
     return data
+
+
+# ── strategy builders --------------------------------------------------------
+
+
+def _base_ticket(
+    strategy: str,
+    symbol: str,
+    expiry: str,
+    qty: int,
+    strikes: List[float],
+    right: str,
+    account: str | None = None,
+):
+    return {
+        "timestamp": dt.datetime.utcnow().isoformat(),
+        "strategy": strategy,
+        "underlying": symbol,
+        "expiry": expiry,
+        "qty": qty,
+        "strikes": strikes,
+        "right": right,
+        "account": account or settings.default_account,
+        "legs": [],
+    }
+
+
+def build_vertical(
+    symbol: str,
+    expiry: str,
+    right: str,
+    strikes: List[float],
+    qty: int,
+    account: str | None = None,
+):
+    k_low, k_high = sorted(strikes)
+    ticket = _base_ticket("vertical", symbol, expiry, qty, [k_low, k_high], right, account)
+    if right == "C":
+        legs = [
+            {"secType": "OPT", "right": "C", "strike": k_low, "qty": qty, "expiry": expiry},
+            {"secType": "OPT", "right": "C", "strike": k_high, "qty": -qty, "expiry": expiry},
+        ]
+    else:  # Puts
+        legs = [
+            {"secType": "OPT", "right": "P", "strike": k_high, "qty": -qty, "expiry": expiry},
+            {"secType": "OPT", "right": "P", "strike": k_low, "qty": qty, "expiry": expiry},
+        ]
+    ticket["legs"] = legs
+    return ticket
+
+
+def build_iron_condor(
+    symbol: str,
+    expiry: str,
+    strikes: List[float],
+    qty: int,
+    account: str | None = None,
+):
+    k1, k2, k3, k4 = sorted(strikes)
+    ticket = _base_ticket(
+        "iron_condor", symbol, expiry, qty, [k1, k2, k3, k4], "", account
+    )
+    legs = [
+        {"secType": "OPT", "right": "P", "strike": k2, "qty": qty, "expiry": expiry},
+        {"secType": "OPT", "right": "P", "strike": k1, "qty": -qty, "expiry": expiry},
+        {"secType": "OPT", "right": "C", "strike": k3, "qty": qty, "expiry": expiry},
+        {"secType": "OPT", "right": "C", "strike": k4, "qty": -qty, "expiry": expiry},
+    ]
+    ticket["legs"] = legs
+    return ticket
+
+
+def build_butterfly(
+    symbol: str,
+    expiry: str,
+    right: str,
+    strikes: List[float],
+    qty: int,
+    account: str | None = None,
+):
+    k1, k2, k3 = sorted(strikes)
+    ticket = _base_ticket("butterfly", symbol, expiry, qty, [k1, k2, k3], right, account)
+    legs = [
+        {"secType": "OPT", "right": right, "strike": k1, "qty": qty, "expiry": expiry},
+        {
+            "secType": "OPT",
+            "right": right,
+            "strike": k2,
+            "qty": -2 * qty,
+            "expiry": expiry,
+        },
+        {"secType": "OPT", "right": right, "strike": k3, "qty": qty, "expiry": expiry},
+    ]
+    ticket["legs"] = legs
+    return ticket
+
+
+def build_calendar(
+    symbol: str,
+    expiry: str,
+    right: str,
+    exp_near: str,
+    exp_far: str,
+    strike: float,
+    qty: int,
+    account: str | None = None,
+):
+    near, far = sorted([exp_near, exp_far])
+    expiry = far  # ticket expiry = far
+    ticket = _base_ticket("calendar", symbol, expiry, qty, [strike], right, account)
+    legs = [
+        {"secType": "OPT", "right": right, "strike": strike, "qty": -qty, "expiry": near},
+        {"secType": "OPT", "right": right, "strike": strike, "qty": qty, "expiry": far},
+    ]
+    ticket["legs"] = legs
+    return ticket
+
+
+def build_straddle(
+    symbol: str,
+    expiry: str,
+    strike: float,
+    qty: int,
+    account: str | None = None,
+):
+    ticket = _base_ticket("straddle", symbol, expiry, qty, [strike], "", account)
+    legs = [
+        {"secType": "OPT", "right": "C", "strike": strike, "qty": qty, "expiry": expiry},
+        {"secType": "OPT", "right": "P", "strike": strike, "qty": qty, "expiry": expiry},
+    ]
+    ticket["legs"] = legs
+    return ticket
+
+
+def build_strangle(
+    symbol: str,
+    expiry: str,
+    put_strike: float,
+    call_strike: float,
+    qty: int,
+    account: str | None = None,
+):
+    k_put, k_call = sorted([put_strike, call_strike])
+    ticket = _base_ticket(
+        "strangle", symbol, expiry, qty, [k_put, k_call], "", account
+    )
+    legs = [
+        {"secType": "OPT", "right": "P", "strike": k_put, "qty": qty, "expiry": expiry},
+        {"secType": "OPT", "right": "C", "strike": k_call, "qty": qty, "expiry": expiry},
+    ]
+    ticket["legs"] = legs
+    return ticket
+
+
+def build_covered_call(
+    symbol: str,
+    expiry: str,
+    call_strike: float,
+    qty: int,
+    account: str | None = None,
+    stock_multiplier: int = 100,
+):
+    ticket = _base_ticket(
+        "covered_call", symbol, expiry, qty, [call_strike], "", account
+    )
+    legs = [
+        {
+            "secType": "OPT",
+            "right": "C",
+            "strike": call_strike,
+            "qty": -abs(qty),
+            "expiry": expiry,
+        },
+        {"secType": "STK", "qty": stock_multiplier * abs(qty)},
+    ]
+    ticket["legs"] = legs
+    return ticket
 
 
 def run() -> bool:
@@ -338,3 +522,101 @@ def run() -> bool:
     fn.write_text(json.dumps(ticket, indent=2))
     print(f"✅ Ticket saved to {fn}")
     return True
+
+
+def cli(argv: List[str] | None = None) -> int:
+    """Non-interactive ticket builder CLI."""
+    import argparse
+    from portfolio_exporter.core.io import save as io_save
+
+    parser = argparse.ArgumentParser(description="Build option strategy tickets")
+    parser.add_argument("--strategy", required=True)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--expiry", default="")
+    parser.add_argument("--expiry-near", dest="expiry_near", default=None)
+    parser.add_argument("--expiry-far", dest="expiry_far", default=None)
+    parser.add_argument("--right", default="")
+    parser.add_argument("--strikes", default="")
+    parser.add_argument("--strike", type=float, default=None)
+    parser.add_argument("--put-strike", dest="put_strike", type=float, default=None)
+    parser.add_argument("--call-strike", dest="call_strike", type=float, default=None)
+    parser.add_argument("--qty", type=int, default=1)
+    parser.add_argument("--account", default=None)
+    args = parser.parse_args(argv)
+
+    strat = args.strategy.lower().replace("-", "_")
+    qty = int(args.qty)
+    ticket: Dict[str, Any]
+
+    if strat == "vertical":
+        strikes = [float(s) for s in args.strikes.split(",") if s]
+        ticket = build_vertical(
+            args.symbol, args.expiry, args.right.upper(), strikes, qty, args.account
+        )
+    elif strat == "iron_condor":
+        strikes = [float(s) for s in args.strikes.split(",") if s]
+        ticket = build_iron_condor(args.symbol, args.expiry, strikes, qty, args.account)
+    elif strat == "butterfly":
+        strikes = [float(s) for s in args.strikes.split(",") if s]
+        ticket = build_butterfly(
+            args.symbol, args.expiry, args.right.upper(), strikes, qty, args.account
+        )
+    elif strat == "calendar":
+        near = args.expiry_near
+        far = args.expiry_far or args.expiry
+        if args.expiry and "," in args.expiry:
+            near, far = [p.strip() for p in args.expiry.split(",", 1)]
+        if not (near and far):
+            parser.error("calendar requires --expiry-near and --expiry-far or --expiry near,far")
+        if args.strike is None:
+            parser.error("calendar requires --strike")
+        ticket = build_calendar(
+            args.symbol,
+            far,
+            args.right.upper(),
+            near,
+            far,
+            float(args.strike),
+            qty,
+            args.account,
+        )
+    elif strat == "straddle":
+        strike = args.strike if args.strike is not None else None
+        if strike is None and args.strikes:
+            strike = float(args.strikes)
+        if strike is None:
+            parser.error("straddle requires --strike")
+        ticket = build_straddle(args.symbol, args.expiry, float(strike), qty, args.account)
+    elif strat == "strangle":
+        if args.put_strike is not None and args.call_strike is not None:
+            put_k, call_k = args.put_strike, args.call_strike
+        else:
+            ks = [float(s) for s in args.strikes.split(",") if s]
+            if len(ks) != 2:
+                parser.error("strangle requires two strikes")
+            put_k, call_k = ks
+        ticket = build_strangle(
+            args.symbol, args.expiry, float(put_k), float(call_k), qty, args.account
+        )
+    elif strat == "covered_call":
+        call_k = args.call_strike if args.call_strike is not None else None
+        if call_k is None and args.strike is not None:
+            call_k = float(args.strike)
+        if call_k is None and args.strikes:
+            call_k = float(args.strikes)
+        if call_k is None:
+            parser.error("covered_call requires --call-strike")
+        ticket = build_covered_call(
+            args.symbol, args.expiry, float(call_k), qty, args.account
+        )
+    else:
+        parser.error(f"Unknown strategy {args.strategy}")
+
+    ts = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    name = f"ticket_{args.symbol}_{ts}"
+    io_save(ticket, name, fmt="json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/tests/test_order_builder_cli.py
+++ b/tests/test_order_builder_cli.py
@@ -1,0 +1,29 @@
+import json
+import subprocess
+import sys
+
+
+def test_cli_vertical_leg_signs(monkeypatch, tmp_path):
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    cmd = [
+        sys.executable,
+        "-m",
+        "portfolio_exporter.scripts.order_builder",
+        "--strategy",
+        "vertical",
+        "--symbol",
+        "XYZ",
+        "--right",
+        "C",
+        "--expiry",
+        "2025-01-17",
+        "--strikes",
+        "100,110",
+        "--qty",
+        "1",
+    ]
+    subprocess.check_call(cmd)
+    ticket_path = next(tmp_path.glob("ticket_*.json"))
+    data = json.loads(ticket_path.read_text())
+    legs = [(leg["right"], leg["strike"], leg["qty"]) for leg in data["legs"]]
+    assert legs == [("C", 100, 1), ("C", 110, -1)]

--- a/tests/test_order_builder_playbook.py
+++ b/tests/test_order_builder_playbook.py
@@ -1,0 +1,111 @@
+import json
+from portfolio_exporter.scripts.order_builder import (
+    build_vertical,
+    build_iron_condor,
+    build_butterfly,
+    build_calendar,
+    build_straddle,
+    build_strangle,
+    build_covered_call,
+)
+
+
+def _leg_map(ticket):
+    return [(leg.get("right", ""), leg.get("strike"), leg["qty"], leg.get("expiry")) for leg in ticket["legs"]]
+
+
+def test_vertical_calls_qty_flip():
+    t = build_vertical("XYZ", "2025-01-17", "C", [100, 110], 1, "acc")
+    assert _leg_map(t) == [("C", 100, 1, "2025-01-17"), ("C", 110, -1, "2025-01-17")]
+    t2 = build_vertical("XYZ", "2025-01-17", "C", [110, 100], -1, "acc")
+    assert _leg_map(t2) == [("C", 100, -1, "2025-01-17"), ("C", 110, 1, "2025-01-17")]
+
+
+def test_vertical_puts_qty_flip():
+    t = build_vertical("XYZ", "2025-01-17", "P", [90, 100], 1, "acc")
+    assert _leg_map(t) == [("P", 100, -1, "2025-01-17"), ("P", 90, 1, "2025-01-17")]
+    t2 = build_vertical("XYZ", "2025-01-17", "P", [100, 90], -1, "acc")
+    assert _leg_map(t2) == [("P", 100, 1, "2025-01-17"), ("P", 90, -1, "2025-01-17")]
+
+
+def test_iron_condor_orientation():
+    t = build_iron_condor("XYZ", "2025-01-17", [95, 90, 105, 110], -1, "acc")
+    assert _leg_map(t) == [
+        ("P", 95, -1, "2025-01-17"),
+        ("P", 90, 1, "2025-01-17"),
+        ("C", 105, -1, "2025-01-17"),
+        ("C", 110, 1, "2025-01-17"),
+    ]
+    t2 = build_iron_condor("XYZ", "2025-01-17", [90, 95, 105, 110], 1, "acc")
+    assert _leg_map(t2) == [
+        ("P", 95, 1, "2025-01-17"),
+        ("P", 90, -1, "2025-01-17"),
+        ("C", 105, 1, "2025-01-17"),
+        ("C", 110, -1, "2025-01-17"),
+    ]
+
+
+def test_butterfly_ratio():
+    t = build_butterfly("XYZ", "2025-01-17", "C", [90, 100, 110], 1, "acc")
+    assert _leg_map(t) == [
+        ("C", 90, 1, "2025-01-17"),
+        ("C", 100, -2, "2025-01-17"),
+        ("C", 110, 1, "2025-01-17"),
+    ]
+    t2 = build_butterfly("XYZ", "2025-01-17", "P", [90, 100, 110], -1, "acc")
+    assert _leg_map(t2) == [
+        ("P", 90, -1, "2025-01-17"),
+        ("P", 100, 2, "2025-01-17"),
+        ("P", 110, -1, "2025-01-17"),
+    ]
+
+
+def test_calendar_flip():
+    t = build_calendar(
+        "XYZ",
+        "2025-02-21",
+        "C",
+        "2025-01-17",
+        "2025-02-21",
+        100,
+        1,
+        "acc",
+    )
+    assert _leg_map(t) == [
+        ("C", 100, -1, "2025-01-17"),
+        ("C", 100, 1, "2025-02-21"),
+    ]
+    t2 = build_calendar(
+        "XYZ",
+        "2025-02-21",
+        "P",
+        "2025-01-17",
+        "2025-02-21",
+        100,
+        -1,
+        "acc",
+    )
+    assert _leg_map(t2) == [
+        ("P", 100, 1, "2025-01-17"),
+        ("P", 100, -1, "2025-02-21"),
+    ]
+
+
+def test_straddle_and_strangle():
+    t = build_straddle("XYZ", "2025-01-17", 100, 1, "acc")
+    assert _leg_map(t) == [
+        ("C", 100, 1, "2025-01-17"),
+        ("P", 100, 1, "2025-01-17"),
+    ]
+    t2 = build_strangle("XYZ", "2025-01-17", 90, 110, -1, "acc")
+    assert _leg_map(t2) == [
+        ("P", 90, -1, "2025-01-17"),
+        ("C", 110, -1, "2025-01-17"),
+    ]
+
+
+def test_covered_call_signs():
+    t = build_covered_call("XYZ", "2025-01-17", 105, -2, "acc")
+    assert _leg_map(t) == [("C", 105, -2, "2025-01-17"), ("", None, 200, None)]
+    t2 = build_covered_call("XYZ", "2025-01-17", 105, 1, "acc")
+    assert _leg_map(t2) == [("C", 105, -1, "2025-01-17"), ("", None, 100, None)]


### PR DESCRIPTION
## Summary
- add pure builder functions for verticals, iron condors, butterflies, calendars, straddles, strangles and covered calls with default leg directions
- wire order_builder CLI to the builders and support near/far expiries and strike parsing
- document non-interactive order builder usage with qty-driven orientation examples

## Testing
- `ruff check portfolio_exporter/scripts/order_builder.py tests/test_order_builder_playbook.py tests/test_order_builder_cli.py`
- `pytest tests/test_order_builder_playbook.py tests/test_order_builder_cli.py tests/test_order_builder.py tests/test_order_builder_caps.py tests/test_order_builder_pricing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b265af370832e8dd70c0285a61745