### PR TITLE
Add daily HTML/PDF portfolio report

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ yfinance can be found in [docs/PDR.md](docs/PDR.md).
 | `update_tickers.py` | Writes the current IBKR stock positions to `tickers_live.txt` so other scripts always use a fresh portfolio. |
 | `net_liq_history_export.py` | Creates an end-of-day Net-Liq history CSV from TWS logs or Client Portal data and can optionally plot an equity curve. Supports `--excel` and `--pdf` outputs. |
 | `trades_report.py` | Exports executions and open orders from IBKR to CSV for a chosen date range. Add `--excel` or `--pdf` for formatted reports. |
+| `daily_report.py` | Render a one-page HTML/PDF snapshot from the latest portfolio greeks CSVs. |
 
 ## Strike Enrichment in Combos
 
@@ -138,6 +139,20 @@ JSON summary fields: `n_total`, `n_kept`, `u_count`, `underlyings`, `net_credit_
 ```
 
 Open interest values are sourced from Yahoo Finance rather than the IBKR feed.
+
+### Daily Report
+
+Create a one-page portfolio snapshot from the latest greeks exports:
+
+```bash
+python -m portfolio_exporter.scripts.daily_report
+python -m portfolio_exporter.scripts.daily_report --json
+python -m portfolio_exporter.scripts.daily_report --output-dir ./reports --html --pdf
+```
+
+The script reads the newest `portfolio_greeks_positions*.csv`,
+`portfolio_greeks_totals*.csv`, and `portfolio_greeks_combos*.csv` files.
+`--since` and `--until` filter positions by expiry when that column exists.
 
 ### Build Order (CLI)
 

--- a/portfolio_exporter/menus/trade.py
+++ b/portfolio_exporter/menus/trade.py
@@ -6,7 +6,9 @@ from portfolio_exporter.scripts import (
     roll_manager,
     option_chain_snapshot,
     net_liq_history_export,
+    daily_report,
 )
+import os
 
 # Menu for trade-related utilities
 
@@ -21,6 +23,7 @@ def launch(status, default_fmt):
             ("l", "Roll positions"),
             ("q", "Quick option chain"),
             ("v", "View Net-Liq chart"),
+            ("d", "Daily report (HTML/PDF)"),
             ("r", "Return"),
         ]:
             tbl.add_row(k, lbl)
@@ -34,6 +37,7 @@ def launch(status, default_fmt):
             "l": lambda: roll_manager.run(),
             "q": lambda: option_chain_snapshot.run(fmt=default_fmt),
             "v": lambda: net_liq_history_export.run(fmt=default_fmt, plot=True),
+            "d": lambda: daily_report.main(["--no-pretty"] if os.getenv("PE_QUIET") else []),
         }.get(ch)
         if dispatch:
             if status:

--- a/portfolio_exporter/scripts/__init__.py
+++ b/portfolio_exporter/scripts/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "risk_watch",
     "theta_cap",
     "gamma_scalp",
+    "daily_report",
     "trades_report",
     "order_builder",
     "roll_manager",

--- a/portfolio_exporter/scripts/daily_report.py
+++ b/portfolio_exporter/scripts/daily_report.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+from rich.console import Console
+
+from portfolio_exporter.core import io as core_io
+from portfolio_exporter.core.config import settings
+
+try:  # optional dependency for PDF output
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Table as RLTable,
+        Paragraph,
+        PageBreak,
+    )
+    from reportlab.lib.styles import getSampleStyleSheet
+except Exception:  # pragma: no cover - optional
+    (
+        SimpleDocTemplate,
+        RLTable,
+        Paragraph,
+        PageBreak,
+        getSampleStyleSheet,
+    ) = (None,) * 5
+
+
+# ---------------------------------------------------------------------------
+# data loaders
+
+
+def _load_csv(name: str) -> pd.DataFrame:
+    path = core_io.latest_file(name)
+    if not path or not path.exists():
+        return pd.DataFrame()
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        return pd.DataFrame()
+
+
+def _prep_positions(df: pd.DataFrame, since: str | None, until: str | None) -> pd.DataFrame:
+    if df.empty:
+        return df
+    if "expiry" in df.columns:
+        df["expiry"] = pd.to_datetime(df["expiry"], errors="coerce").dt.date
+        if since:
+            df = df[df["expiry"] >= datetime.fromisoformat(since).date()]
+        if until:
+            df = df[df["expiry"] <= datetime.fromisoformat(until).date()]
+        df["expiry"] = df["expiry"].astype(str)
+    cols = ["underlying", "right", "strike", "expiry", "qty"]
+    greek_cols = [c for c in ["delta", "gamma", "vega", "theta"] if c in df.columns]
+    exposure_cols = [
+        c
+        for c in ["delta_exposure", "gamma_exposure", "vega_exposure", "theta_exposure"]
+        if c in df.columns
+    ]
+    keep = [c for c in cols + greek_cols + exposure_cols if c in df.columns]
+    return df[keep]
+
+
+def _prep_combos(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    if "expiry" in df.columns:
+        df["expiry"] = pd.to_datetime(df["expiry"], errors="coerce").dt.date.astype(str)
+    cols = [
+        "underlying",
+        "expiry",
+        "structure_label",
+        "structure",
+        "type",
+        "width",
+        "strikes",
+        "call_strikes",
+        "put_strikes",
+        "call_count",
+        "put_count",
+        "legs_n",
+    ]
+    df = df[[c for c in cols if c in df.columns]]
+    if "structure_label" in df.columns:
+        df = df.rename(columns={"structure_label": "structure"})
+    return df.sort_values(["underlying", "expiry"], ascending=[True, False]).head(50)
+
+
+# ---------------------------------------------------------------------------
+# output builders
+
+
+def _build_html(
+    outdir: Path, totals: pd.DataFrame, combos: pd.DataFrame, positions: pd.DataFrame, account: str | None
+) -> str:
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    parts = ["<h1>Daily Portfolio Report</h1>"]
+    parts.append(f"<p>Generated: {ts}</p>")
+    if account:
+        parts.append(f"<p>Account: {account}</p>")
+    parts.append(f"<p>Output dir: {outdir}</p>")
+    if not totals.empty:
+        parts.append("<h2>Totals</h2>")
+        parts.append(totals.to_html(index=False))
+    if not combos.empty:
+        parts.append("<h2>Combos</h2>")
+        parts.append(combos.to_html(index=False))
+    if not positions.empty:
+        parts.append("<h2>Positions</h2>")
+        parts.append(positions.to_html(index=False))
+    return "\n".join(parts)
+
+
+def _build_pdf_flowables(
+    outdir: Path, totals: pd.DataFrame, combos: pd.DataFrame, positions: pd.DataFrame, account: str | None
+):
+    if SimpleDocTemplate is None:
+        return []
+    styles = getSampleStyleSheet()
+    flow = [Paragraph("Daily Portfolio Report", styles["Heading1"])]
+    flow.append(Paragraph(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), styles["Normal"]))
+    if account:
+        flow.append(Paragraph(f"Account: {account}", styles["Normal"]))
+    flow.append(Paragraph(f"Output dir: {outdir}", styles["Normal"]))
+    if not totals.empty:
+        flow.append(Paragraph("Totals", styles["Heading2"]))
+        flow.append(RLTable([totals.columns.tolist()] + totals.values.tolist()))
+    if not combos.empty:
+        flow.append(PageBreak())
+        flow.append(Paragraph("Combos", styles["Heading2"]))
+        flow.append(RLTable([combos.columns.tolist()] + combos.values.tolist()))
+    if not positions.empty:
+        flow.append(PageBreak())
+        flow.append(Paragraph("Positions", styles["Heading2"]))
+        flow.append(RLTable([positions.columns.tolist()] + positions.values.tolist()))
+    return flow
+
+
+# ---------------------------------------------------------------------------
+# main
+
+
+def main(argv: list[str] | None = None) -> dict:
+    parser = argparse.ArgumentParser(description="Render portfolio report from latest CSVs")
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--html", action="store_true")
+    parser.add_argument("--pdf", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--no-pretty", action="store_true")
+    parser.add_argument("--since")
+    parser.add_argument("--until")
+    parser.add_argument("--combos-source", default="csv")
+    args = parser.parse_args(argv)
+
+    if not args.html and not args.pdf:
+        args.html = args.pdf = True
+
+    console = Console() if not args.no_pretty else None
+
+    positions = _prep_positions(_load_csv("portfolio_greeks_positions"), args.since, args.until)
+    totals = _load_csv("portfolio_greeks_totals")
+    combos = _prep_combos(_load_csv("portfolio_greeks_combos"))
+
+    outdir = Path(args.output_dir or settings.output_dir).expanduser()
+    account = totals["account"].iloc[0] if "account" in totals.columns and not totals.empty else None
+
+    summary = {
+        "positions_rows": len(positions),
+        "combos_rows": len(combos),
+        "totals_rows": len(totals),
+        "outputs": {},
+    }
+
+    html_str = None
+    if args.html or args.pdf:
+        html_str = _build_html(outdir, totals, combos, positions, account)
+
+    if args.html and html_str is not None:
+        path_html = core_io.save(html_str, "daily_report", "html", outdir)
+        summary["outputs"]["html"] = str(path_html)
+        if console:
+            console.print(f"HTML report → {path_html}")
+    if args.pdf:
+        flowables = _build_pdf_flowables(outdir, totals, combos, positions, account)
+        path_pdf = core_io.save(flowables, "daily_report", "pdf", outdir)
+        summary["outputs"]["pdf"] = str(path_pdf)
+        if console:
+            console.print(f"PDF report → {path_pdf}")
+
+    if args.json:
+        print(json.dumps(summary))
+    return summary
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/data/combos_sample.csv
+++ b/tests/data/combos_sample.csv
@@ -1,0 +1,3 @@
+underlying,expiry,structure_label,type,width,strikes,call_strikes,put_strikes,call_count,put_count,legs_n
+AAPL,2024-01-19,Bfly,credit,5,"150/155/160","150/155","160",2,1,3
+MSFT,2024-02-16,Straddle,debit,,300,,300,1,1,2

--- a/tests/data/positions_sample.csv
+++ b/tests/data/positions_sample.csv
@@ -1,0 +1,3 @@
+underlying,right,strike,expiry,qty,delta,gamma,vega,theta,delta_exposure,gamma_exposure
+AAPL,C,150,2024-01-19,1,0.5,0.1,0.2,-0.01,50,10
+MSFT,P,280,2024-02-16,-2,-0.6,0.12,0.25,0.015,-120,24

--- a/tests/data/totals_sample.csv
+++ b/tests/data/totals_sample.csv
@@ -1,0 +1,2 @@
+account,net_liq,delta,gamma,vega,theta
+DU12345,100000,10,1,20,-5

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from portfolio_exporter.scripts import daily_report
+
+
+def _fake_latest_factory(base: Path):
+    mapping = {
+        "portfolio_greeks_positions": base / "positions_sample.csv",
+        "portfolio_greeks_totals": base / "totals_sample.csv",
+        "portfolio_greeks_combos": base / "combos_sample.csv",
+    }
+
+    def _latest(name: str, fmt: str = "csv", outdir: str | None = None):
+        return mapping.get(name)
+
+    return _latest
+
+
+def test_daily_report_full(monkeypatch, tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    monkeypatch.setattr(
+        "portfolio_exporter.core.io.latest_file", _fake_latest_factory(data_dir)
+    )
+    res = daily_report.main(["--json", "--output-dir", str(tmp_path)])
+    assert res["positions_rows"] == 2
+    assert res["combos_rows"] == 2
+    assert res["totals_rows"] == 1
+    assert (tmp_path / "daily_report.html").exists()
+    assert (tmp_path / "daily_report.pdf").exists()
+    assert set(res["outputs"].keys()) == {"html", "pdf"}
+
+
+def test_daily_report_missing(monkeypatch, tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    def _latest(name: str, fmt: str = "csv", outdir: str | None = None):
+        mapping = {"portfolio_greeks_positions": data_dir / "positions_sample.csv"}
+        return mapping.get(name)
+
+    monkeypatch.setattr("portfolio_exporter.core.io.latest_file", _latest)
+    res = daily_report.main(["--json", "--output-dir", str(tmp_path)])
+    assert res["positions_rows"] == 2
+    assert res["combos_rows"] == 0
+    assert res["totals_rows"] == 0
+    assert set(res["outputs"].keys()) == {"html", "pdf"}


### PR DESCRIPTION
## Summary
- add `daily_report.py` to render latest portfolio greeks CSVs into an HTML/PDF snapshot and JSON summary
- extend `core.io.save` to accept HTML strings and PDF flowables
- wire trade menu with new daily report option and document usage in README

## Testing
- `ruff check portfolio_exporter/scripts/daily_report.py tests/test_daily_report.py portfolio_exporter/core/io.py portfolio_exporter/menus/trade.py`
- `pytest -q tests/test_daily_report.py`


------
https://chatgpt.com/codex/tasks/task_e_689b6d381714832eb3cea45e010de622