### PR TITLE
Modernize Net-Liq history exporter CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,29 @@ Tips
 - `--output-dir`: Override the destination directory for artifacts.
 - Env override: set `OUTPUT_DIR=./.outputs` in a `.env` file to change the default output path (picked up by settings).
 
+### Net-Liq chart (CLI)
+
+JSON only:
+
+```bash
+PYTHONPATH=. python -m portfolio_exporter.scripts.net_liq_history_export \
+  --source fixture --fixture-csv tests/data/net_liq_fixture.csv --json --quiet
+```
+
+Multi-format to custom dir:
+
+```bash
+OUT=.tmp_nlh PYTHONPATH=. python -m portfolio_exporter.scripts.net_liq_history_export \
+  --source fixture --fixture-csv tests/data/net_liq_fixture.csv \
+  --csv --pdf --output-dir "$OUT" --quiet
+```
+
+Date filtering:
+
+```bash
+python -m portfolio_exporter.scripts.net_liq_history_export --start 2025-01-01 --end 2025-03-31 --json
+```
+
 ### Build Order (CLI)
 
 The non-interactive order builder creates normalized ticket JSONs for common strategies.

--- a/portfolio_exporter/menus/trade.py
+++ b/portfolio_exporter/menus/trade.py
@@ -22,7 +22,7 @@ def launch(status, default_fmt):
             ("b", "Build order"),
             ("l", "Roll positions"),
             ("q", "Quick option chain"),
-            ("v", "View Net-Liq chart"),
+            ("n", "Net-Liq (CLI)"),
             ("d", "Daily report (HTML/PDF)"),
             ("r", "Return"),
         ]:
@@ -36,8 +36,12 @@ def launch(status, default_fmt):
             "b": order_builder.run,
             "l": lambda: roll_manager.run(),
             "q": lambda: option_chain_snapshot.run(fmt=default_fmt),
-            "v": lambda: net_liq_history_export.run(fmt=default_fmt, plot=True),
-            "d": lambda: daily_report.main(["--no-pretty"] if os.getenv("PE_QUIET") else []),
+            "n": lambda: net_liq_history_export.main(
+                ["--quiet", "--no-pretty"] if os.getenv("PE_QUIET") else []
+            ),
+            "d": lambda: daily_report.main(
+                ["--no-pretty"] if os.getenv("PE_QUIET") else []
+            ),
         }.get(ch)
         if dispatch:
             if status:

--- a/tests/test_net_liq_cli.py
+++ b/tests/test_net_liq_cli.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 
 def _run_cli(args, env):
@@ -18,36 +19,56 @@ def _run_cli(args, env):
     return result.stdout
 
 
+def _have_reportlab() -> bool:
+    try:
+        import reportlab  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
 def test_json_no_write(tmp_path):
     env = os.environ.copy()
     env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1", "PE_OUTPUT_DIR": str(tmp_path)})
-    out = _run_cli([
-        "--fixture-csv",
-        "tests/data/net_liq_fixture.csv",
-        "--json",
-    ], env)
+    out = _run_cli(
+        [
+            "--source",
+            "fixture",
+            "--fixture-csv",
+            "tests/data/net_liq_fixture.csv",
+            "--json",
+            "--quiet",
+        ],
+        env,
+    )
     data = json.loads(out)
     assert data["rows"] == 10
-    assert data["date_min"] == "2024-01-02"
-    assert data["date_max"] == "2024-01-16"
+    assert data["start"] == "2024-01-02"
+    assert data["end"] == "2024-01-16"
     assert data["outputs"] == {"csv": "", "excel": "", "pdf": ""}
     assert not any(tmp_path.iterdir())
 
 
-def test_json_write_outputs(tmp_path):
+@pytest.mark.skipif(not _have_reportlab(), reason="reportlab not installed")
+def test_file_writes(tmp_path):
     env = os.environ.copy()
     env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1"})
     outdir = tmp_path / ".tmp_nlh"
-    out = _run_cli([
-        "--fixture-csv",
-        "tests/data/net_liq_fixture.csv",
-        "--json",
-        "--write",
-        "--output-dir",
-        str(outdir),
-        "--csv",
-        "--pdf",
-    ], env)
+    out = _run_cli(
+        [
+            "--source",
+            "fixture",
+            "--fixture-csv",
+            "tests/data/net_liq_fixture.csv",
+            "--json",
+            "--output-dir",
+            str(outdir),
+            "--csv",
+            "--pdf",
+            "--quiet",
+        ],
+        env,
+    )
     data = json.loads(out)
     csv_path = Path(data["outputs"]["csv"])
     pdf_path = Path(data["outputs"]["pdf"])
@@ -58,18 +79,51 @@ def test_json_write_outputs(tmp_path):
     assert len(df) == 10
 
 
+def test_date_filter(tmp_path):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1", "PE_OUTPUT_DIR": str(tmp_path)})
+    out = _run_cli(
+        [
+            "--source",
+            "fixture",
+            "--fixture-csv",
+            "tests/data/net_liq_fixture.csv",
+            "--start",
+            "2024-01-03",
+            "--end",
+            "2024-01-05",
+            "--json",
+        ],
+        env,
+    )
+    data = json.loads(out)
+    assert data["rows"] == 3
+    assert data["start"] == "2024-01-03"
+    assert data["end"] == "2024-01-05"
+
+
 def test_quiet_suppresses_table(tmp_path):
     env = os.environ.copy()
     env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1", "PE_OUTPUT_DIR": str(tmp_path)})
-    loud = _run_cli([
-        "--fixture-csv",
-        "tests/data/net_liq_fixture.csv",
-    ], env)
+    loud = _run_cli(
+        [
+            "--source",
+            "fixture",
+            "--fixture-csv",
+            "tests/data/net_liq_fixture.csv",
+        ],
+        env,
+    )
     assert "NetLiq" in loud
-    quiet = _run_cli([
-        "--fixture-csv",
-        "tests/data/net_liq_fixture.csv",
-        "--quiet",
-    ], env)
+    quiet = _run_cli(
+        [
+            "--source",
+            "fixture",
+            "--fixture-csv",
+            "tests/data/net_liq_fixture.csv",
+            "--quiet",
+        ],
+        env,
+    )
     assert quiet.strip() == ""
 


### PR DESCRIPTION
## Summary
- expand `net_liq_history_export` with a full argparse CLI, JSON summaries and fixture support
- unify saving through `core.io.save` with basic ReportLab PDF tables
- wire the CLI into the Trades & Reports menu and document usage

## Testing
- `ruff check portfolio_exporter/scripts/net_liq_history_export.py portfolio_exporter/core/io.py portfolio_exporter/menus/trade.py tests/test_net_liq_cli.py`
- `pytest -q tests/test_net_liq_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689b7319c650832e9aa04cea957e0355