### PR TITLE
Add expiry radar and symbol filter to daily report

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,41 @@ python -m portfolio_exporter.scripts.daily_report
 python -m portfolio_exporter.scripts.daily_report --json
 python -m portfolio_exporter.scripts.daily_report --output-dir ./reports --html --pdf
 python -m portfolio_exporter.scripts.daily_report --json --no-files   # JSON only, no files written
+python -m portfolio_exporter.scripts.daily_report --expiry-window 10
+python -m portfolio_exporter.scripts.daily_report --symbol AAPL
+python -m portfolio_exporter.scripts.daily_report --symbol AAPL --expiry-window 7 --json --no-files --quiet
 ```
 
 The script reads the newest `portfolio_greeks_positions*.csv`,
 `portfolio_greeks_totals*.csv`, and `portfolio_greeks_combos*.csv` files.
 `--since` and `--until` filter positions by expiry when that column exists.
+`--expiry-window N` adds an "Expiry Radar" section for contracts expiring in the
+next `N` days (defaults to 10 when the flag is provided without a value).
+`--symbol TICKER` restricts report inputs to the given underlying (case-insensitive).
+
+When `--json` is used, the output includes an `expiry_radar` block:
+
+```json
+{
+  "expiry_radar": {
+    "window_days": 7,
+    "basis": "combos",
+    "rows": [
+      {
+        "date": "YYYY-MM-DD",
+        "count": 2,
+        "delta_total": 0.5,
+        "theta_total": -1.2,
+        "by_structure": {"vertical": 1, "iron condor": 1}
+      }
+    ]
+  },
+  "filters": {"symbol": "AAPL"}
+}
+```
+
+`basis` falls back to `"positions"` if combo data is unavailable. Roll-off greek
+totals appear only when the relevant columns exist.
 
 Tips
 - `--no-files`: Suppress writing HTML/PDF; useful in CI/sandboxes with `--json`.

--- a/tests/data/combos_expiry_sample.csv
+++ b/tests/data/combos_expiry_sample.csv
@@ -1,0 +1,4 @@
+underlying,expiry,structure_label,type,width,strikes,call_strikes,put_strikes,call_count,put_count,legs_n
+aapl,2024-01-12,vertical,credit,5,"150/155","150","155",1,1,2
+msft,2024-01-15,iron condor,credit,10,"300/310/320/330","300/310","320/330",2,2,4
+goog,2024-01-20,calendar,debit,,"1350/1350","1350","1350",1,1,2

--- a/tests/test_daily_report_expiry_radar.py
+++ b/tests/test_daily_report_expiry_radar.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+from datetime import datetime
+
+from portfolio_exporter.scripts import daily_report
+
+
+class FixedDate(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2024, 1, 10)
+
+
+def _fake_latest_factory(mapping: dict[str, Path]):
+    def _latest(name: str, fmt: str = "csv", outdir: str | None = None):
+        return mapping.get(name)
+
+    return _latest
+
+
+def test_expiry_radar_combos(monkeypatch):
+    data_dir = Path(__file__).parent / "data"
+    mapping = {
+        "portfolio_greeks_positions": data_dir / "positions_sample.csv",
+        "portfolio_greeks_totals": data_dir / "totals_sample.csv",
+        "portfolio_greeks_combos": data_dir / "combos_expiry_sample.csv",
+    }
+    monkeypatch.setattr("portfolio_exporter.core.io.latest_file", _fake_latest_factory(mapping))
+    monkeypatch.setattr(daily_report, "datetime", FixedDate)
+    res = daily_report.main(["--json", "--expiry-window", "7"])
+    radar = res["expiry_radar"]
+    assert radar["basis"] == "combos"
+    assert radar["window_days"] == 7
+    assert radar["rows"]
+    assert any("by_structure" in r for r in radar["rows"])
+
+
+def test_expiry_radar_positions_fallback(monkeypatch):
+    data_dir = Path(__file__).parent / "data"
+    mapping = {
+        "portfolio_greeks_positions": data_dir / "positions_sample.csv",
+    }
+    monkeypatch.setattr("portfolio_exporter.core.io.latest_file", _fake_latest_factory(mapping))
+    monkeypatch.setattr(daily_report, "datetime", FixedDate)
+    res = daily_report.main(["--json", "--expiry-window", "10"])
+    radar = res["expiry_radar"]
+    assert radar["basis"] == "positions"
+    assert radar["rows"]
+
+
+def test_expiry_radar_symbol_filter(monkeypatch):
+    data_dir = Path(__file__).parent / "data"
+    mapping = {
+        "portfolio_greeks_positions": data_dir / "positions_sample.csv",
+        "portfolio_greeks_totals": data_dir / "totals_sample.csv",
+        "portfolio_greeks_combos": data_dir / "combos_expiry_sample.csv",
+    }
+    monkeypatch.setattr("portfolio_exporter.core.io.latest_file", _fake_latest_factory(mapping))
+    monkeypatch.setattr(daily_report, "datetime", FixedDate)
+    res = daily_report.main(["--json", "--expiry-window", "7", "--symbol", "AAPL"])
+    assert res["positions_rows"] == 1
+    assert res["combos_rows"] == 1
+    assert res["filters"] == {"symbol": "AAPL"}
+    radar = res["expiry_radar"]
+    assert radar["rows"] and radar["rows"][0]["count"] == 1
+    assert radar["rows"][0].get("by_structure", {}) == {"vertical": 1}
+
+
+def test_expiry_radar_disabled(monkeypatch):
+    data_dir = Path(__file__).parent / "data"
+    mapping = {
+        "portfolio_greeks_positions": data_dir / "positions_sample.csv",
+        "portfolio_greeks_combos": data_dir / "combos_expiry_sample.csv",
+    }
+    monkeypatch.setattr("portfolio_exporter.core.io.latest_file", _fake_latest_factory(mapping))
+    monkeypatch.setattr(daily_report, "datetime", FixedDate)
+    res = daily_report.main(["--json", "--expiry-window", "0"])
+    assert "expiry_radar" not in res


### PR DESCRIPTION
## Summary
- add `--symbol` filter applied to positions, totals and combos
- introduce `--expiry-window` to render an expiry radar section in HTML/PDF/JSON
- document new flags and JSON shape
- test expiry radar generation and symbol filtering

## Testing
- `ruff check portfolio_exporter/scripts/daily_report.py tests/test_daily_report_expiry_radar.py`
- `pytest -q tests/test_daily_report_expiry_radar.py`
- `pytest -q tests/test_daily_report.py`
- `PYTHONPATH=. PE_QUIET=1 OUTPUT_DIR=/tmp/daily_data python -m portfolio_exporter.scripts.daily_report --expiry-window 7 --symbol AAPL --json --no-files`
- `PYTHONPATH=. OUTPUT_DIR=/tmp/daily_data python -m portfolio_exporter.scripts.daily_report --expiry-window 10 --output-dir .tmp_daily`

------
https://chatgpt.com/codex/tasks/task_e_689c172147ec832ebdc990b86097bea2