### PR TITLE
Add shared CLI helpers and unify script JSON summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ Environment and configuration
 
 See `.env.example` for a starter file; any values there are read by the app.
 
+## Common CLI flags
+
+Most scripts share a small set of flags for consistent ergonomics:
+
+| Flag | Description |
+| ---- | ----------- |
+| `--output-dir PATH` | Directory for generated files (overrides `OUTPUT_DIR` env). |
+| `--json` | Emit a compact JSON summary to STDOUT. |
+| `--no-files` | Skip writing any output files. |
+| `--no-pretty` | Disable rich/pretty console rendering. |
+
+Environment variables:
+
+| Variable | Purpose |
+| -------- | ------- |
+| `OUTPUT_DIR` | Default directory for exports. |
+| `PE_QUIET` | When set to `1`, suppresses all pretty console output. |
+
+JSON summaries returned by the scripts consistently use `sections` or `rows`
+and include an `outputs` mapping with file paths (empty strings when skipped).
+
 ## Upgrading dependencies
 
 This project uses the [pip-tools](https://github.com/jazzband/pip-tools) workflow to maintain fully pinned requirements.

--- a/portfolio_exporter/core/cli.py
+++ b/portfolio_exporter/core/cli.py
@@ -1,0 +1,81 @@
+"""Shared CLI helpers.
+
+Provides small utilities to keep behaviour across scripts
+consistent.  Each helper is intentionally tiny and free of any
+third‑party dependencies so importing this module has negligible
+startup cost.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from .config import settings
+
+
+def resolve_output_dir(arg: str | None) -> Path:
+    """Return the effective output directory.
+
+    Preference order:
+    1. Explicit argument ``arg``.
+    2. ``OUTPUT_DIR`` environment variable.
+    3. ``PE_OUTPUT_DIR`` environment variable (backwards compatibility).
+    4. ``settings.output_dir`` from configuration.
+    """
+
+    env = os.getenv("OUTPUT_DIR") or os.getenv("PE_OUTPUT_DIR")
+    base = arg or env or settings.output_dir
+    return Path(base).expanduser()
+
+
+def resolve_quiet(no_pretty: bool) -> tuple[bool, bool]:
+    """Determine quiet/pretty flags.
+
+    ``PE_QUIET=1`` forces quiet mode regardless of ``no_pretty``.
+    Returns ``(quiet, pretty)``.
+    """
+
+    quiet_env = os.getenv("PE_QUIET") not in (None, "", "0")
+    quiet = bool(quiet_env)
+    pretty = not quiet and not no_pretty
+    return quiet, pretty
+
+
+def decide_file_writes(
+    args: Any,
+    *,
+    json_only_default: bool,
+    defaults: Dict[str, bool],
+) -> Dict[str, bool]:
+    """Determine which output formats should be written.
+
+    ``defaults`` maps format names to their default enabled state.
+    ``json_only_default`` controls whether ``--json`` without an
+    ``--output-dir`` disables file writes.
+    """
+
+    formats = {k: bool(getattr(args, k, False)) for k in defaults}
+    if getattr(args, "no_files", False):
+        return {k: False for k in defaults}
+
+    if any(formats.values()):
+        return formats
+
+    if json_only_default and getattr(args, "json", False) and getattr(args, "output_dir", None) is None:
+        return {k: False for k in defaults}
+
+    return defaults
+
+
+def print_json(data: Dict[str, Any], quiet: bool) -> None:
+    """Emit JSON to STDOUT.
+
+    Always prints compact JSON (no whitespace).  ``quiet`` is accepted so
+    callers can unconditionally pass the value returned from
+    :func:`resolve_quiet`; JSON is still printed in quiet mode.
+    """
+
+    txt = json.dumps(data, separators=(",", ":"))
+    print(txt)

--- a/portfolio_exporter/core/json.py
+++ b/portfolio_exporter/core/json.py
@@ -1,0 +1,41 @@
+"""Small helpers for consistent JSON summaries."""
+from __future__ import annotations
+
+from typing import Dict, List, Mapping, Any
+
+
+def _base(outputs: Mapping[str, str], warnings: List[str] | None, meta: Dict[str, Any] | None) -> Dict[str, Any]:
+    return {
+        "ok": True,
+        "outputs": {k: v for k, v in outputs.items()},
+        "warnings": warnings or [],
+        "meta": meta or {},
+    }
+
+
+def time_series_summary(
+    rows: int,
+    start: str | None,
+    end: str | None,
+    outputs: Mapping[str, str],
+    warnings: List[str] | None = None,
+    meta: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Build a standardised summary for time‑series exports."""
+
+    base = _base(outputs, warnings, meta)
+    base.update({"rows": rows, "start": start, "end": end})
+    return base
+
+
+def report_summary(
+    sections: Mapping[str, int],
+    outputs: Mapping[str, str],
+    warnings: List[str] | None = None,
+    meta: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Build a summary for multi‑section reports."""
+
+    base = _base(outputs, warnings, meta)
+    base.update({"sections": dict(sections)})
+    return base

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -22,9 +22,9 @@ def test_daily_report_full(monkeypatch, tmp_path):
         "portfolio_exporter.core.io.latest_file", _fake_latest_factory(data_dir)
     )
     res = daily_report.main(["--json", "--output-dir", str(tmp_path)])
-    assert res["positions_rows"] == 2
-    assert res["combos_rows"] == 2
-    assert res["totals_rows"] == 1
+    assert res["sections"]["positions"] == 2
+    assert res["sections"]["combos"] == 2
+    assert res["sections"]["totals"] == 1
     assert (tmp_path / "daily_report.html").exists()
     assert (tmp_path / "daily_report.pdf").exists()
     assert set(res["outputs"].keys()) == {"html", "pdf"}
@@ -38,7 +38,19 @@ def test_daily_report_missing(monkeypatch, tmp_path):
 
     monkeypatch.setattr("portfolio_exporter.core.io.latest_file", _latest)
     res = daily_report.main(["--json", "--output-dir", str(tmp_path)])
-    assert res["positions_rows"] == 2
-    assert res["combos_rows"] == 0
-    assert res["totals_rows"] == 0
+    assert res["sections"]["positions"] == 2
+    assert res["sections"]["combos"] == 0
+    assert res["sections"]["totals"] == 0
     assert set(res["outputs"].keys()) == {"html", "pdf"}
+
+
+def test_daily_report_json_only(monkeypatch, tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    monkeypatch.setattr(
+        "portfolio_exporter.core.io.latest_file", _fake_latest_factory(data_dir)
+    )
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    res = daily_report.main(["--json"])
+    assert res["sections"]["positions"] == 2
+    assert res["outputs"] == {"html": "", "pdf": ""}
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_net_liq_cli.py
+++ b/tests/test_net_liq_cli.py
@@ -63,17 +63,14 @@ def test_file_writes(tmp_path):
             "--json",
             "--output-dir",
             str(outdir),
-            "--csv",
-            "--pdf",
             "--quiet",
         ],
         env,
     )
     data = json.loads(out)
     csv_path = Path(data["outputs"]["csv"])
-    pdf_path = Path(data["outputs"]["pdf"])
     assert csv_path.exists()
-    assert pdf_path.exists()
+    assert data["outputs"]["pdf"] == ""
     df = pd.read_csv(csv_path)
     assert list(df.columns) == ["date", "NetLiq"]
     assert len(df) == 10

--- a/tests/test_quick_chain_cli.py
+++ b/tests/test_quick_chain_cli.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 import sys
 import importlib
+import os
+import json
 
 
 def test_json_summary_no_files(tmp_path):
@@ -18,7 +20,6 @@ def test_json_summary_no_files(tmp_path):
             "portfolio_exporter/scripts/quick_chain.py",
             "--chain-csv",
             "tests/data/quick_chain_fixture.csv",
-            "--no-pretty",
             "--json",
         ],
         capture_output=True,
@@ -27,8 +28,8 @@ def test_json_summary_no_files(tmp_path):
         env=env,
     )
     data = json.loads(result.stdout)
-    assert data["rows"] > 0
-    assert data["underlyings"]
+    assert data["sections"]["chain"] > 0
+    assert data["meta"]["underlyings"]
     assert not any(tmp_path.iterdir())
 
 
@@ -71,5 +72,5 @@ def test_lazy_deps(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     data = json.loads(out)
     assert code == 0
-    assert data["rows"] > 0
+    assert data["sections"]["chain"] > 0
     assert not any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- add reusable CLI helpers and JSON summary builders
- refactor daily report, net-liq export and quick-chain scripts to use common flags
- document common CLI flags and update tests

## Testing
- `ruff check portfolio_exporter/core/cli.py portfolio_exporter/core/json.py portfolio_exporter/scripts/daily_report.py portfolio_exporter/scripts/net_liq_history_export.py portfolio_exporter/scripts/quick_chain.py tests/test_daily_report.py tests/test_net_liq_cli.py tests/test_quick_chain_cli.py`
- `pytest -q tests/test_daily_report.py tests/test_net_liq_cli.py tests/test_quick_chain_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689c1da1bfc0832e8e0a2ff603e0af88