### PR TITLE
Refactor trade and greeks scripts to use core CLI

### DIFF
--- a/tests/test_portfolio_greeks_cli.py
+++ b/tests/test_portfolio_greeks_cli.py
@@ -1,0 +1,56 @@
+import json
+import os
+import subprocess
+import sys
+
+
+def test_json_only_outputs_empty(tmp_path):
+    env = {
+        "PYTHONPATH": ".",
+        "PE_TEST_MODE": "1",
+        "PE_OUTPUT_DIR": str(tmp_path),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/portfolio_greeks.py",
+            "--positions-csv",
+            "tests/data/positions_sample.csv",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout.splitlines()[-1])
+    assert data["outputs"] == []
+    assert not any(tmp_path.iterdir())
+
+
+def test_output_dir_writes_csvs(tmp_path):
+    env = {"PYTHONPATH": ".", "PE_TEST_MODE": "1"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/portfolio_greeks.py",
+            "--positions-csv",
+            "tests/data/positions_sample.csv",
+            "--output-dir",
+            str(tmp_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout.splitlines()[-1])
+    for name in [
+        "portfolio_greeks_positions.csv",
+        "portfolio_greeks_totals.csv",
+        "portfolio_greeks_combos.csv",
+    ]:
+        p = tmp_path / name
+        assert p.exists()
+        assert str(p) in data["outputs"]

--- a/tests/test_trades_report_cli.py
+++ b/tests/test_trades_report_cli.py
@@ -1,0 +1,60 @@
+import json
+import subprocess
+import sys
+
+def _make_exec_csv(tmp_path):
+    path = tmp_path / "exec.csv"
+    path.write_text(
+        "exec_id,perm_id,order_id,symbol,secType,Side,qty,price,datetime,Liquidation,lastLiquidity,OrderRef\n"
+        "1,1,1,AAPL,STK,BOT,1,10.0,2024-01-01T10:00:00,0,1,\n"
+    )
+    return path
+
+
+def test_json_only_outputs_empty(tmp_path):
+    exec_csv = _make_exec_csv(tmp_path)
+    env = {
+        "PYTHONPATH": ".",
+        "PE_TEST_MODE": "1",
+        "PE_OUTPUT_DIR": str(tmp_path),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/trades_report.py",
+            "--executions-csv",
+            str(exec_csv),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout.splitlines()[-1])
+    assert data["outputs"] == []
+    assert not list(tmp_path.glob("trades_report*.csv"))
+
+
+def test_output_dir_writes_csv(tmp_path):
+    exec_csv = _make_exec_csv(tmp_path)
+    env = {"PYTHONPATH": ".", "PE_TEST_MODE": "1"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/trades_report.py",
+            "--executions-csv",
+            str(exec_csv),
+            "--output-dir",
+            str(tmp_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout.splitlines()[-1])
+    report_files = list(tmp_path.glob("trades_report*.csv"))
+    assert report_files
+    assert str(report_files[0]) in data["outputs"]


### PR DESCRIPTION
## Summary
- migrate trades_report and portfolio_greeks to shared core CLI helpers and JSON summaries
- ensure optional dependencies do not crash when missing
- add CLI tests for trades and greeks reports

## Testing
- `ruff check portfolio_exporter/scripts/trades_report.py portfolio_exporter/scripts/portfolio_greeks.py tests/test_trades_report_cli.py tests/test_portfolio_greeks_cli.py`
- `pytest -q tests/test_trades_report_cli.py tests/test_portfolio_greeks_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689c320ef5e8832ebcd1ec2909f93c3a