### PR TITLE
Add delta bucket and theta decay metrics to daily report

### DIFF
--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from portfolio_exporter.scripts import daily_report
 
 
@@ -25,6 +27,15 @@ def test_daily_report_full(monkeypatch, tmp_path):
     assert res["sections"]["positions"] == 2
     assert res["sections"]["combos"] == 2
     assert res["sections"]["totals"] == 1
+    assert res["delta_buckets"] == {
+        "(-1,-0.6]": 1,
+        "(-0.6,-0.3]": 0,
+        "(-0.3,0]": 0,
+        "(0,0.3]": 0,
+        "(0.3,0.6]": 1,
+        "(0.6,1]": 0,
+    }
+    assert res["theta_decay_5d"] == pytest.approx(0.025)
     assert (tmp_path / "daily_report.html").exists()
     assert (tmp_path / "daily_report.pdf").exists()
     # outputs list should contain both files
@@ -44,6 +55,9 @@ def test_daily_report_missing(monkeypatch, tmp_path):
     assert res["sections"]["positions"] == 2
     assert res["sections"]["combos"] == 0
     assert res["sections"]["totals"] == 0
+    assert res["delta_buckets"]["(-1,-0.6]"] == 1
+    assert res["delta_buckets"]["(0.3,0.6]"] == 1
+    assert res["theta_decay_5d"] == pytest.approx(0.025)
     outs = set(res["outputs"])
     assert any(str(p).endswith("daily_report.html") for p in outs)
     assert any(str(p).endswith("daily_report.pdf") for p in outs)
@@ -57,5 +71,7 @@ def test_daily_report_json_only(monkeypatch, tmp_path):
     monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
     res = daily_report.main(["--json"])
     assert res["sections"]["positions"] == 2
+    assert res["delta_buckets"]["(-1,-0.6]"] == 1
+    assert res["theta_decay_5d"] == pytest.approx(0.025)
     assert res["outputs"] == []
     assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- add delta bucket analytics and 5-day theta decay projection to daily report
- render delta and theta sections in HTML and PDF outputs
- cover new metrics with tests and fixtures

## Testing
- `ruff check portfolio_exporter/scripts/daily_report.py tests/test_daily_report.py tests/test_daily_report_expiry_radar.py`
- `pytest -q tests/test_daily_report.py tests/test_daily_report_expiry_radar.py`


------
https://chatgpt.com/codex/tasks/task_e_689c38ce04b0832e897749d5caa0570c