### PR TITLE
Add JSON contracts and preflight checks

### DIFF
--- a/portfolio_exporter/core/json.py
+++ b/portfolio_exporter/core/json.py
@@ -1,7 +1,10 @@
 """Small helpers for consistent JSON summaries."""
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Any
+from typing import Any, Dict, List, Mapping
+
+
+SCHEMA_VERSION = "1.0.0"
 
 
 def _base(
@@ -30,6 +33,7 @@ def time_series_summary(
 ) -> Dict[str, Any]:
     """Build a standardised summary for time‑series exports."""
 
+    meta = {**(meta or {}), "schema_id": "time_series_summary", "schema_version": SCHEMA_VERSION}
     base = _base(outputs, warnings, meta)
     base.update({"rows": rows, "start": start, "end": end})
     return base
@@ -43,6 +47,7 @@ def report_summary(
 ) -> Dict[str, Any]:
     """Build a summary for multi‑section reports."""
 
+    meta = {**(meta or {}), "schema_id": "report_summary", "schema_version": SCHEMA_VERSION}
     base = _base(outputs, warnings, meta)
     base.update({"sections": dict(sections)})
     return base

--- a/portfolio_exporter/core/schemas.py
+++ b/portfolio_exporter/core/schemas.py
@@ -1,0 +1,58 @@
+"""Optional Pandera schemas for CSV preflight checks."""
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+
+try:  # optional pandera dependency
+    import pandera as pa
+except Exception:  # pragma: no cover - optional
+    pa = None  # type: ignore
+
+
+if pa:  # pragma: no branch
+
+    class PositionsSchema(pa.DataFrameModel):
+        underlying: pa.typing.Series[str]
+        right: pa.typing.Series[str]
+        strike: pa.typing.Series[float]
+        expiry: pa.typing.Series[str]
+        qty: pa.typing.Series[float]
+
+    class TotalsSchema(pa.DataFrameModel):
+        account: pa.typing.Series[str]
+        net_liq: pa.typing.Series[float]
+
+    class CombosSchema(pa.DataFrameModel):
+        underlying: pa.typing.Series[str]
+        expiry: pa.typing.Series[str]
+        structure_label: pa.typing.Series[str]
+        type: pa.typing.Series[str]
+
+    class TradesSchema(pa.DataFrameModel):
+        ticker: pa.typing.Series[str]
+        side: pa.typing.Series[str]
+        qty: pa.typing.Series[float]
+        price: pa.typing.Series[float]
+
+    SCHEMAS = {
+        "positions": PositionsSchema.to_schema(),
+        "totals": TotalsSchema.to_schema(),
+        "combos": CombosSchema.to_schema(),
+        "trades": TradesSchema.to_schema(),
+    }
+
+    def check_headers(name: str, df: pd.DataFrame) -> List[str]:
+        schema = SCHEMAS.get(name)
+        if schema is None:
+            return []
+        missing = set(schema.columns.keys()) - set(df.columns)
+        if missing:
+            return [f"missing columns {sorted(missing)}"]
+        return []
+
+else:  # pandera not installed
+
+    def check_headers(name: str, df: pd.DataFrame) -> List[str]:  # type: ignore[override]
+        return ["pandera not installed"]

--- a/portfolio_exporter/scripts/__init__.py
+++ b/portfolio_exporter/scripts/__init__.py
@@ -17,4 +17,6 @@ __all__ = [
     "order_builder",
     "roll_manager",
     "quick_chain",
+    "validate_json",
+    "doctor",
 ]

--- a/portfolio_exporter/scripts/doctor.py
+++ b/portfolio_exporter/scripts/doctor.py
@@ -1,0 +1,81 @@
+"""Environment and data sanity checks."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from portfolio_exporter.core import cli as cli_helpers
+from portfolio_exporter.core import io as core_io
+from portfolio_exporter.core import json as json_helpers
+from portfolio_exporter.core import schemas as pa_schemas
+from portfolio_exporter.core.config import settings
+
+
+def cli(ns: argparse.Namespace) -> dict[str, Any]:
+    warnings: list[str] = []
+    sections: dict[str, int] = {}
+    ok = True
+
+    # Env vars
+    env_vars = ["OUTPUT_DIR"]
+    missing = [e for e in env_vars if not os.getenv(e)]
+    if missing:
+        warnings.append(f"missing env vars: {', '.join(missing)}")
+    sections["env"] = len(env_vars)
+
+    # Output dir
+    base = os.getenv("OUTPUT_DIR") or settings.output_dir
+    outdir = Path(base).expanduser()
+    try:
+        outdir.mkdir(parents=True, exist_ok=True)
+        test = outdir / ".pe_write_test"
+        test.write_text("ok")
+        test.unlink()
+    except Exception as e:
+        warnings.append(f"OUTPUT_DIR not writable: {e}")
+        ok = False
+    sections["output_dir"] = 1
+
+    # Header checks
+    checks = 0
+    for name in ["positions", "totals", "combos", "trades"]:
+        path = core_io.latest_file(f"portfolio_greeks_{name}")
+        if path and path.exists():
+            checks += 1
+            try:
+                df = pd.read_csv(path)
+            except Exception as e:  # pragma: no cover - IO errors
+                warnings.append(f"{path.name}: {e}")
+                ok = False
+                continue
+            msgs = pa_schemas.check_headers(name, df)
+            for msg in msgs:
+                warnings.append(f"{path.name}: {msg}")
+            if msgs and not any("pandera" in m for m in msgs):
+                ok = False
+    sections["headers"] = checks
+
+    summary = json_helpers.report_summary(sections, outputs={})
+    summary["warnings"].extend(warnings)
+    summary["ok"] = ok
+    summary["meta"]["script"] = "doctor"
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run environment checks")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--no-files", action="store_true")
+    args = parser.parse_args(argv)
+    summary = cli(args)
+    if args.json:
+        cli_helpers.print_json(summary, True)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/portfolio_exporter/scripts/validate_json.py
+++ b/portfolio_exporter/scripts/validate_json.py
@@ -1,0 +1,31 @@
+"""Validate JSON summaries against local schemas."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+
+SCHEMA_DIR = Path(__file__).resolve().parents[2] / "schemas"
+
+
+def validate(obj: dict) -> None:
+    schema_id = obj.get("meta", {}).get("schema_id")
+    if not schema_id:
+        raise SystemExit("missing meta.schema_id")
+    path = SCHEMA_DIR / f"{schema_id}.schema.json"
+    with path.open() as fh:
+        schema = json.load(fh)
+    jsonschema.validate(obj, schema)
+
+
+def main(argv: list[str] | None = None) -> int:
+    data = json.load(sys.stdin)
+    validate(data)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,8 @@ idna==3.10
     # via requests
 iniconfig==2.1.0
     # via pytest
+jsonschema==4.25.0
+    # via -r requirements-dev.in
 mypy-extensions==1.1.0
     # via black
 numpy==2.3.2
@@ -34,6 +36,8 @@ packaging==25.0
     #   build
     #   pytest
 pandas==2.3.1
+    # via -r requirements-dev.in
+pandera==0.26.0
     # via -r requirements-dev.in
 pathspec==0.12.1
     # via black

--- a/schemas/report_summary.schema.json
+++ b/schemas/report_summary.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Report Summary",
+  "type": "object",
+  "required": ["ok", "outputs", "warnings", "meta", "sections"],
+  "properties": {
+    "ok": {"type": "boolean"},
+    "outputs": {"type": "array", "items": {"type": "string"}},
+    "warnings": {"type": "array", "items": {"type": "string"}},
+    "meta": {
+      "type": "object",
+      "required": ["schema_id", "schema_version"],
+      "properties": {
+        "schema_id": {"const": "report_summary"},
+        "schema_version": {"const": "1.0.0"}
+      },
+      "additionalProperties": true
+    },
+    "sections": {"type": "object"}
+  },
+  "additionalProperties": true
+}

--- a/schemas/time_series_summary.schema.json
+++ b/schemas/time_series_summary.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Time Series Summary",
+  "type": "object",
+  "required": ["ok", "outputs", "warnings", "meta", "rows", "start", "end"],
+  "properties": {
+    "ok": {"type": "boolean"},
+    "outputs": {"type": "array", "items": {"type": "string"}},
+    "warnings": {"type": "array", "items": {"type": "string"}},
+    "meta": {
+      "type": "object",
+      "required": ["schema_id", "schema_version"],
+      "properties": {
+        "schema_id": {"const": "time_series_summary"},
+        "schema_version": {"const": "1.0.0"}
+      },
+      "additionalProperties": true
+    },
+    "rows": {"type": "integer"},
+    "start": {"type": ["string", "null"]},
+    "end": {"type": ["string", "null"]}
+  },
+  "additionalProperties": true
+}

--- a/tests/test_doctor_preflight.py
+++ b/tests/test_doctor_preflight.py
@@ -1,0 +1,65 @@
+import argparse
+from pathlib import Path
+
+from portfolio_exporter.scripts import daily_report, portfolio_greeks, doctor
+
+
+def test_doctor_ok(monkeypatch):
+    monkeypatch.setenv("OUTPUT_DIR", "tests/data")
+    summary = doctor.cli(argparse.Namespace())  # type: ignore
+    assert summary["ok"] is True
+
+
+def test_doctor_header_fail(tmp_path, monkeypatch):
+    csv = tmp_path / "portfolio_greeks_positions.csv"
+    csv.write_text("underlying,qty\nAAPL,1\n")
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    summary = doctor.cli(argparse.Namespace())  # type: ignore
+    assert summary["ok"] is False
+
+
+def test_daily_report_preflight(monkeypatch, tmp_path):
+    samples = {
+        "positions_sample.csv": "portfolio_greeks_positions.csv",
+        "totals_sample.csv": "portfolio_greeks_totals.csv",
+        "combos_sample.csv": "portfolio_greeks_combos.csv",
+    }
+    for src, dst in samples.items():
+        (tmp_path / dst).write_text((Path("tests/data") / src).read_text())
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    res = daily_report.main(["--preflight", "--json", "--no-files"])
+    assert res["ok"] is True
+
+
+def test_daily_report_preflight_fail(tmp_path, monkeypatch):
+    p = tmp_path / "portfolio_greeks_positions.csv"
+    p.write_text("underlying,qty\nAAPL,1\n")
+    (tmp_path / "portfolio_greeks_totals.csv").write_text("account,net_liq\nA,1\n")
+    (tmp_path / "portfolio_greeks_combos.csv").write_text("underlying\nAAPL\n")
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    res = daily_report.main(["--preflight", "--json", "--no-files"])
+    assert res["ok"] is False
+
+
+def test_portfolio_greeks_preflight(monkeypatch):
+    res = portfolio_greeks.main([
+        "--positions-csv",
+        "tests/data/positions_sample.csv",
+        "--json",
+        "--no-files",
+        "--preflight",
+    ])
+    assert res["ok"] is True
+
+
+def test_portfolio_greeks_preflight_fail(tmp_path):
+    bad = tmp_path / "pos.csv"
+    bad.write_text("underlying,qty\nAAPL,1\n")
+    res = portfolio_greeks.main([
+        "--positions-csv",
+        str(bad),
+        "--json",
+        "--no-files",
+        "--preflight",
+    ])
+    assert res["ok"] is False

--- a/tests/test_json_contracts.py
+++ b/tests/test_json_contracts.py
@@ -1,0 +1,22 @@
+import json
+
+from portfolio_exporter.scripts import daily_report, net_liq_history_export, validate_json
+
+
+def test_daily_report_schema(monkeypatch):
+    monkeypatch.setenv("OUTPUT_DIR", "tests/data")
+    res = daily_report.main(["--json", "--no-files"])
+    validate_json.validate(res)
+
+
+def test_net_liq_schema(monkeypatch, capsys):
+    net_liq_history_export.main([
+        "--json",
+        "--no-files",
+        "--source",
+        "fixture",
+        "--fixture-csv",
+        "tests/data/net_liq_fixture.csv",
+    ])
+    data = json.loads(capsys.readouterr().out)
+    validate_json.validate(data)


### PR DESCRIPTION
## Summary
- define JSON schemas for time-series and report summaries
- add optional Pandera-based CSV header checks and preflight hooks
- introduce doctor and validate_json utilities

## Testing
- `ruff check .`
- `pytest -q tests/test_json_contracts.py tests/test_doctor_preflight.py`
- `PYTHONPATH=. OUTPUT_DIR=tests/data PE_QUIET=1 python -m portfolio_exporter.scripts.daily_report --expiry-window 7 --json --no-files | python -m portfolio_exporter.scripts.validate_json`
- `PYTHONPATH=. PE_QUIET=1 python -m portfolio_exporter.scripts.net_liq_history_export --json --no-files --source fixture --fixture-csv tests/data/net_liq_fixture.csv | python -m portfolio_exporter.scripts.validate_json`
- `PYTHONPATH=. PE_QUIET=1 python -m portfolio_exporter.scripts.doctor --json --no-files | jq -e '.ok==true'`
- `PYTHONPATH=. OUTPUT_DIR=tests/data python -m portfolio_exporter.scripts.daily_report --json --no-files --preflight | jq -e '.ok==true'`
- `PYTHONPATH=. python -m portfolio_exporter.scripts.portfolio_greeks --positions-csv tests/data/positions_sample.csv --json --no-files --preflight | jq -e '.ok==true'`


------
https://chatgpt.com/codex/tasks/task_e_689c4b6cf330832e8c06af606a0e7c6c