### PR TITLE
Add stage timing debug support

### DIFF
--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -75,3 +75,25 @@ def test_daily_report_json_only(monkeypatch, tmp_path):
     assert res["sections"]["theta_decay_5d"] == pytest.approx(0.025)
     assert res["outputs"] == []
     assert list(tmp_path.iterdir()) == []
+
+
+def test_daily_report_debug_timings_json(monkeypatch, tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    monkeypatch.setattr(
+        "portfolio_exporter.core.io.latest_file", _fake_latest_factory(data_dir)
+    )
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    res = daily_report.main(["--json", "--debug-timings"])
+    assert res["meta"]["timings"]
+    assert res["outputs"] == []
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_daily_report_debug_timings_file(monkeypatch, tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    monkeypatch.setattr(
+        "portfolio_exporter.core.io.latest_file", _fake_latest_factory(data_dir)
+    )
+    res = daily_report.main(["--json", "--output-dir", str(tmp_path), "--debug-timings"])
+    assert any(str(p).endswith("timings.csv") for p in res["outputs"])
+    assert (tmp_path / "timings.csv").exists()

--- a/tests/test_net_liq_cli.py
+++ b/tests/test_net_liq_cli.py
@@ -125,3 +125,47 @@ def test_quiet_suppresses_table(tmp_path):
         env,
     )
     assert quiet.strip() == ""
+
+
+def test_debug_timings_json(tmp_path):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1", "PE_OUTPUT_DIR": str(tmp_path)})
+    out = _run_cli(
+        [
+            "--source",
+            "fixture",
+            "--fixture-csv",
+            "tests/data/net_liq_fixture.csv",
+            "--json",
+            "--debug-timings",
+            "--quiet",
+        ],
+        env,
+    )
+    data = json.loads(out)
+    assert data["meta"]["timings"]
+    assert not any(tmp_path.iterdir())
+
+
+@pytest.mark.skipif(not _have_reportlab(), reason="reportlab not installed")
+def test_debug_timings_file(tmp_path):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1"})
+    outdir = tmp_path / ".tmp_nlh"
+    out = _run_cli(
+        [
+            "--source",
+            "fixture",
+            "--fixture-csv",
+            "tests/data/net_liq_fixture.csv",
+            "--json",
+            "--output-dir",
+            str(outdir),
+            "--debug-timings",
+            "--quiet",
+        ],
+        env,
+    )
+    data = json.loads(out)
+    assert any(p.endswith("timings.csv") for p in data["outputs"])
+    assert (outdir / "timings.csv").exists()

--- a/tests/test_quick_chain_cli.py
+++ b/tests/test_quick_chain_cli.py
@@ -74,3 +74,49 @@ def test_lazy_deps(monkeypatch, tmp_path, capsys):
     assert code == 0
     assert data["sections"]["chain"] > 0
     assert not any(tmp_path.iterdir())
+
+
+def test_debug_timings_json(tmp_path):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1", "PE_OUTPUT_DIR": str(tmp_path), "PE_QUIET": "1"})
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/quick_chain.py",
+            "--chain-csv",
+            "tests/data/quick_chain_fixture.csv",
+            "--json",
+            "--debug-timings",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout)
+    assert data["meta"]["timings"]
+    assert not any(tmp_path.iterdir())
+
+
+def test_debug_timings_file(tmp_path):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1", "PE_QUIET": "1"})
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/quick_chain.py",
+            "--chain-csv",
+            "tests/data/quick_chain_fixture.csv",
+            "--json",
+            "--output-dir",
+            str(tmp_path),
+            "--debug-timings",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout)
+    assert any(p.endswith("timings.csv") for p in data["outputs"])
+    assert (tmp_path / "timings.csv").exists()

--- a/tests/test_runlog.py
+++ b/tests/test_runlog.py
@@ -1,0 +1,22 @@
+import pytest
+from portfolio_exporter.core.runlog import RunLog
+
+
+def test_runlog_timings(monkeypatch):
+    import portfolio_exporter.core.runlog as rl_mod
+
+    calls = [0.0, 0.1, 0.2, 0.3, 0.4]  # enter + two stages
+    def fake_perf_counter():
+        return calls.pop(0)
+
+    monkeypatch.setattr(rl_mod, 'perf_counter', fake_perf_counter)
+
+    with RunLog(script='test') as rl:
+        with rl.time('stage1'):
+            pass
+        with rl.time('stage2'):
+            pass
+    assert rl.timings == [
+        {'stage': 'stage1', 'ms': 100},
+        {'stage': 'stage2', 'ms': 100},
+    ]


### PR DESCRIPTION
## Summary
- track per-stage timings via RunLog.time context manager
- add --debug-timings to daily_report, net_liq_history_export, and quick_chain, saving timings.csv when files are written
- unit test RunLog timings and smoke test debug-timings flags

## Testing
- `make lint`
- `pytest -q tests/test_runlog.py`
- `pytest -q tests/test_daily_report.py -k debug_timings_json`
- `pytest -q tests/test_daily_report.py -k debug_timings_file`
- `pytest -q tests/test_net_liq_cli.py -k debug_timings_json`
- `pytest -q tests/test_net_liq_cli.py -k debug_timings_file` *(skipped: reportlab not installed)*
- `pytest -q tests/test_quick_chain_cli.py -k debug_timings_json`
- `pytest -q tests/test_quick_chain_cli.py -k debug_timings_file`


------
https://chatgpt.com/codex/tasks/task_e_689c5e19ed38832e9ebb894964fb57af