### PR TITLE
Add console entry points and dev convenience

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include schemas/*.json

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,16 @@ PYTEST=$(VENV)/bin/pytest
 .PHONY: setup test lint build ci-home memory-validate memory-view memory-tasks memory-questions memory-context memory-bootstrap memory-digest memory-rotate
 
 setup:
-	python -m venv $(VENV)
-	$(PIP) install -r requirements.txt
-	$(PIP) install -r requirements-dev.txt
+        python -m venv $(VENV)
+        $(PIP) install -r requirements.txt
+        $(PIP) install -r requirements-dev.txt
+
+dev:
+        @mkdir -p .outputs
+        @echo "OUTPUT_DIR=.outputs" > .env
+        @echo "PE_QUIET=1" >> .env
+        ruff check .
+        pytest -q tests/test_json_contracts.py tests/test_doctor_preflight.py
 
 # ------------------------------------------------------------------
 # Home-lab CI pipeline (single-thread, minimal RAM)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ Environment variables:
 JSON summaries returned by the scripts consistently use `sections` or `rows`
 and include an `outputs` mapping with file paths (empty strings when skipped).
 
+## Console entry points
+
+```bash
+daily-report --json --no-files
+netliq-export --json --no-files --source fixture --fixture-csv tests/data/net_liq_fixture.csv
+quick-chain --chain-csv tests/data/quick_chain_fixture.csv --json
+trades-report --executions-csv tests/data/executions_fixture.csv --json
+portfolio-greeks --positions-csv tests/data/positions_sample.csv --json
+doctor --json --no-files
+daily-report --json --no-files | validate-json
+```
+
 ## Repo Memory (Agent-Shared)
 
 Lightweight, auditable repo “memory” helps Cloud/CLI agents keep context across sessions.

--- a/portfolio_exporter/scripts/quick_chain.py
+++ b/portfolio_exporter/scripts/quick_chain.py
@@ -485,5 +485,18 @@ def _run_cli_v3() -> int:
         return 0
 
 
+def main(argv: list[str] | None = None) -> int:
+    if argv is not None:
+        import sys
+
+        old = sys.argv
+        sys.argv = [sys.argv[0]] + argv
+        try:
+            return _run_cli_v3()
+        finally:
+            sys.argv = old
+    return _run_cli_v3()
+
+
 if __name__ == "__main__":  # pragma: no cover
-    raise SystemExit(_run_cli_v3())
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,13 @@ pdf = ["reportlab>=4.0"]
 
 [project.scripts]
 portfolio_playbook = "main:main"
+daily-report = "portfolio_exporter.scripts.daily_report:main"
+netliq-export = "portfolio_exporter.scripts.net_liq_history_export:main"
+quick-chain = "portfolio_exporter.scripts.quick_chain:main"
+trades-report = "portfolio_exporter.scripts.trades_report:main"
+portfolio-greeks = "portfolio_exporter.scripts.portfolio_greeks:main"
+doctor = "portfolio_exporter.scripts.doctor:main"
+validate-json = "portfolio_exporter.scripts.validate_json:main"
 
 [tool.setuptools.packages.find]
 include = ["portfolio_exporter*"]
@@ -42,3 +49,7 @@ exclude = ["legacy*", "tests*", "utils*", "docs*", "ibkr_env*", "iv_history*"]
 
 [tool.setuptools]
 py-modules = ["main"]
+include-package-data = true
+
+[tool.setuptools.data-files]
+"schemas" = ["schemas/*.json"]

--- a/tests/data/executions_fixture.csv
+++ b/tests/data/executions_fixture.csv
@@ -1,0 +1,2 @@
+exec_id,perm_id,order_id,symbol,secType,Side,qty,price,datetime,Liquidation,lastLiquidity,OrderRef
+1,1,1,AAPL,STK,BOT,1,10.0,2024-01-01T10:00:00,0,1,

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,75 @@
+import importlib
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path("tests/data")
+
+@pytest.mark.parametrize(
+    "mod_path, argv, needs_env",
+    [
+        ("portfolio_exporter.scripts.daily_report", ["--json", "--no-files"], False),
+        (
+            "portfolio_exporter.scripts.net_liq_history_export",
+            [
+                "--json",
+                "--no-files",
+                "--source",
+                "fixture",
+                "--fixture-csv",
+                str(FIXTURES / "net_liq_fixture.csv"),
+            ],
+            False,
+        ),
+        (
+            "portfolio_exporter.scripts.quick_chain",
+            ["--chain-csv", str(FIXTURES / "quick_chain_fixture.csv"), "--json"],
+            False,
+        ),
+        (
+            "portfolio_exporter.scripts.trades_report",
+            ["--executions-csv", str(FIXTURES / "executions_fixture.csv"), "--json"],
+            False,
+        ),
+        (
+            "portfolio_exporter.scripts.portfolio_greeks",
+            [
+                "--positions-csv",
+                str(FIXTURES / "positions_sample.csv"),
+                "--json",
+                "--no-files",
+                "--combos-source",
+                "engine",
+            ],
+            False,
+        ),
+        ("portfolio_exporter.scripts.doctor", ["--json", "--no-files"], True),
+    ],
+)
+def test_entrypoint_main_ok(mod_path, argv, needs_env, monkeypatch, capsys, tmp_path):
+    if needs_env:
+        monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    mod = importlib.import_module(mod_path)
+    result = mod.main(argv)
+    out = capsys.readouterr().out
+    if isinstance(result, dict):
+        assert result.get("ok")
+    else:
+        data = json.loads(out.splitlines()[-1])
+        assert data.get("ok")
+
+
+def test_validate_json_entrypoint(monkeypatch):
+    mod = importlib.import_module("portfolio_exporter.scripts.validate_json")
+    sample = {
+        "ok": True,
+        "outputs": [],
+        "warnings": [],
+        "meta": {"schema_id": "report_summary", "schema_version": "1.0.0"},
+        "sections": {},
+    }
+    monkeypatch.setattr(sys, "stdin", StringIO(json.dumps(sample)))
+    assert mod.main([]) == 0


### PR DESCRIPTION
## Summary
- expose daily-report, netliq-export, quick-chain and other CLIs via project scripts
- include JSON schemas in wheel/sdist and provide dev Makefile target
- document console entry points and add smoke tests for each main

## Testing
- `ruff check .`
- `pytest -q tests/test_json_contracts.py tests/test_doctor_preflight.py tests/test_entrypoints.py`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_689dadf5d28c832e994392b560287c6a