### PR TITLE
Add trades clustering to trades_report

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ python -m portfolio_exporter.scripts.trades_report --since 2025-08-09 --until 20
 python -m portfolio_exporter.scripts.trades_report --executions-csv tests/data/offline_executions_combo_sample.csv --since 2025-08-01 --until 2025-08-31 --debug-combos
 ```
 
+### Trades clustering
+
+Group executions into clusters and compute synthetic P&L:
+
+```bash
+python -m portfolio_exporter.scripts.trades_report --executions-csv tests/data/executions_fixture.csv --json
+```
+
 JSON summary fields: `n_total`, `n_kept`, `u_count`, `underlyings`, `net_credit_debit`, `combos_total`, `combos_by_structure`, and `outputs` (paths when written).
 ```
 

--- a/docs/codex_runs.md
+++ b/docs/codex_runs.md
@@ -1,0 +1,6 @@
+### TRADES_CLUSTERING_V1
+- v1.0.0
+- v1.0.1
+- v1.0.2
+- v1.1.0
+- chosen: v1.1.0

--- a/tests/test_trades_clusters_cli.py
+++ b/tests/test_trades_clusters_cli.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+import sys
+
+
+def test_clusters_json_only(tmp_path):
+    env = {
+        "PYTHONPATH": ".",
+        "PE_TEST_MODE": "1",
+        "PE_OUTPUT_DIR": str(tmp_path),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/trades_report.py",
+            "--executions-csv",
+            "tests/data/executions_fixture.csv",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout.splitlines()[-1])
+    assert data["outputs"] == []
+    assert data["sections"]["clusters"] == 1
+    assert data["sections"]["combos"] == 0
+    assert not list(tmp_path.glob("trades_clusters*.csv"))
+
+
+def test_clusters_output_dir(tmp_path):
+    outdir = tmp_path / ".tmp_trades"
+    env = {"PYTHONPATH": ".", "PE_TEST_MODE": "1"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "portfolio_exporter/scripts/trades_report.py",
+            "--executions-csv",
+            "tests/data/executions_fixture.csv",
+            "--output-dir",
+            str(outdir),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    data = json.loads(result.stdout.splitlines()[-1])
+    clusters_path = outdir / "trades_clusters.csv"
+    manifest_path = outdir / "trades_report_manifest.json"
+    assert clusters_path.exists()
+    assert manifest_path.exists()
+    assert str(clusters_path) in data["outputs"]
+    assert str(manifest_path) in data["outputs"]


### PR DESCRIPTION
## Summary
- cluster executions by perm_id or time window and compute synthetic P&L
- add CLI flags and outputs for trades_clusters including optional debug info
- document trades clustering usage and codex run entry

## Testing
- `ruff check .`
- `pytest -q tests/test_trades_clusters_cli.py`
- `pytest -q tests/test_trades_report_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc16149cc832ebe7d091b9384edd8