### PR TITLE
Add roll manager dry-run preview and per-symbol limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,19 @@ python trades_report.py --today
 
 ```bash
 python -m portfolio_exporter.scripts.roll_manager --days 28 --tenor monthly --no-pretty
-python -m portfolio_exporter.scripts.roll_manager --json
+python -m portfolio_exporter.scripts.roll_manager --dry-run --json --no-files
+python -m portfolio_exporter.scripts.roll_manager --limit-per-underlying 1 --output-dir rolls
 ```
+
+JSON-only preview:
+
+```bash
+python -m portfolio_exporter.scripts.roll_manager --dry-run --json --no-files
+```
+
+Flags are unified across CLIs: `--json`, `--no-files`, `--output-dir`, `--no-pretty` and `--debug-timings`.
+When writing files, a RunLog manifest is saved; `--debug-timings` adds `timings.csv` and includes
+timings data in the JSON summary.
 
 ### Trades Report
 

--- a/docs/codex/ROLL_MANAGER_DRYRUN_V1_2025-08-14_12-12_v1.md
+++ b/docs/codex/ROLL_MANAGER_DRYRUN_V1_2025-08-14_12-12_v1.md
@@ -1,0 +1,16 @@
+# Roll Manager Dry-Run Enhancements
+
+## Candidates
+- V1: `--dry-run` flag with JSON preview and per-underlying limits.
+- V2: Persist timings and manifest.
+- V3: Integrate RunLog with optional `--debug-timings`.
+- V4: Documentation and test coverage.
+
+## Chosen Version
+V1
+
+## Tests / Smokes
+- `pytest tests/test_roll_manager_cli.py`
+
+## Follow-ups
+- Consider richer warning collection and user feedback.

--- a/tests/test_roll_manager_cli.py
+++ b/tests/test_roll_manager_cli.py
@@ -1,10 +1,10 @@
 import argparse
-import types
-import argparse
-import types
 import importlib.util
 import pathlib
+import types
+
 import pandas as pd
+
 
 spec = importlib.util.spec_from_file_location(
     "roll_manager",
@@ -15,34 +15,141 @@ roll_manager = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(roll_manager)
 
 
-def _stub_positions():
-    return pd.DataFrame()
-
-
 def _stub_spinner(msg, fn, *a, **k):
     return fn(*a, **k)
 
 
-def test_run_returns_df(monkeypatch):
-    fake_pg = types.SimpleNamespace(_load_positions=_stub_positions)
-    monkeypatch.setattr(roll_manager, "portfolio_greeks", fake_pg)
-    monkeypatch.setattr(roll_manager, "run_with_spinner", _stub_spinner)
-    df = roll_manager.run(return_df=True)
-    assert isinstance(df, pd.DataFrame)
+def _fixtures():
+    pos_df = pd.DataFrame(
+        {
+            "qty": [1, -1, 1, -1, 1, -1],
+            "strike": [100, 105, 110, 115, 50, 55],
+            "right": ["C", "C", "C", "C", "P", "P"],
+            "delta": [0.5, -0.4, 0.6, -0.5, -0.3, 0.2],
+            "gamma": [0.1, -0.1, 0.2, -0.2, -0.05, 0.04],
+            "theta": [-0.01, 0.01, -0.02, 0.02, 0.01, -0.01],
+            "vega": [0.1, -0.1, 0.15, -0.15, -0.05, 0.05],
+            "multiplier": [100] * 6,
+        },
+        index=[1, 2, 3, 4, 5, 6],
+    )
+
+    combos_df = pd.DataFrame(
+        {
+            "underlying": ["AAPL", "AAPL", "MSFT"],
+            "expiry": [pd.Timestamp("2025-08-21")] * 3,
+            "legs": [[1, 2], [3, 4], [5, 6]],
+            "qty": [1, 1, 1],
+            "type": ["other", "other", "other"],
+        },
+        index=[0, 1, 2],
+    )
+
+    def _fake_positions():
+        return pos_df
+
+    def _fake_detect(_df):
+        return combos_df
+
+    def _fake_chain(symbol, expiry, strikes):  # noqa: ARG001
+        rows: list[dict] = []
+        for s in strikes:
+            rows.append(
+                {
+                    "strike": s,
+                    "right": "C",
+                    "mid": 1.0,
+                    "delta": 0.4,
+                    "gamma": 0.1,
+                    "theta": -0.02,
+                    "vega": 0.15,
+                }
+            )
+            rows.append(
+                {
+                    "strike": s,
+                    "right": "P",
+                    "mid": 1.0,
+                    "delta": -0.4,
+                    "gamma": 0.1,
+                    "theta": -0.02,
+                    "vega": 0.15,
+                }
+            )
+        return pd.DataFrame(rows)
+
+    return pos_df, _fake_positions, _fake_detect, _fake_chain
 
 
-def test_cli_json(monkeypatch):
-    fake_pg = types.SimpleNamespace(_load_positions=_stub_positions)
+def _prep(monkeypatch):
+    pos_df, fake_positions, fake_detect, fake_chain = _fixtures()
+    fake_pg = types.SimpleNamespace(_load_positions=fake_positions)
     monkeypatch.setattr(roll_manager, "portfolio_greeks", fake_pg)
     monkeypatch.setattr(roll_manager, "run_with_spinner", _stub_spinner)
+    monkeypatch.setattr(roll_manager, "detect_combos", fake_detect)
+    monkeypatch.setattr(roll_manager, "fetch_chain", fake_chain)
+    return pos_df
+
+
+def test_dry_run_json_only(monkeypatch):
+    _prep(monkeypatch)
     ns = argparse.Namespace(
         include_cal=False,
         days=7,
         tenor="all",
+        limit_per_underlying=None,
+        dry_run=True,
+        debug_timings=False,
         no_pretty=True,
         json=True,
         output_dir=None,
+        no_files=True,
     )
     summary = roll_manager.cli(ns)
-    for key in ["n_candidates", "n_selected", "underlyings", "by_structure", "outputs"]:
-        assert key in summary
+    assert summary["ok"] is True
+    assert summary["sections"]["candidates"] > 0
+    assert summary["outputs"] == []
+
+
+def test_with_files(tmp_path, monkeypatch):
+    _prep(monkeypatch)
+    outdir = tmp_path / ".tmp_rolls"
+    ns = argparse.Namespace(
+        include_cal=False,
+        days=7,
+        tenor="all",
+        limit_per_underlying=None,
+        dry_run=False,
+        debug_timings=False,
+        no_pretty=True,
+        json=True,
+        output_dir=str(outdir),
+        no_files=False,
+    )
+    summary = roll_manager.cli(ns)
+    assert any("roll_preview" in p for p in summary["outputs"])
+    assert any("roll_ticket" in p for p in summary["outputs"])
+    assert (outdir / "roll_manager_manifest.json").exists()
+
+
+def test_limit_per_underlying(monkeypatch):
+    _prep(monkeypatch)
+    ns = argparse.Namespace(
+        include_cal=False,
+        days=7,
+        tenor="all",
+        limit_per_underlying=1,
+        dry_run=True,
+        debug_timings=False,
+        no_pretty=True,
+        json=True,
+        output_dir=None,
+        no_files=True,
+    )
+    summary = roll_manager.cli(ns)
+    assert summary["meta"]["limits"]["per_underlying"] == 1
+    counts: dict[str, int] = {}
+    for cand in summary["candidates"]:
+        counts[cand["underlying"]] = counts.get(cand["underlying"], 0) + 1
+    assert all(v <= 1 for v in counts.values())
+


### PR DESCRIPTION
## Summary
- support `--dry-run` JSON previews and `--limit-per-underlying` for roll_manager
- integrate RunLog with manifest and optional timings
- document new CLI flags and create codex run log

## Testing
- `ruff check portfolio_exporter/scripts/roll_manager.py tests/test_roll_manager_cli.py`
- `pytest -q tests/test_roll_manager_cli.py`
- `make lint` *(fails: missing separator (did you mean TAB instead of 8 spaces?))*
- `make memory-validate` *(fails: missing separator (did you mean TAB instead of 8 spaces?))*
- `python -m portfolio_exporter.scripts.memory validate` *(fails: No module named portfolio_exporter.scripts.memory)*

------
https://chatgpt.com/codex/tasks/task_e_689dd185962c832e8c55a6ee57118a0d