### PR TITLE
Add combo DB maintenance CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ doctor --json --no-files
 daily-report --json --no-files | validate-json
 ```
 
+## Combo DB maintenance
+
+`combo-db-maint` audits and repairs the combos database.
+
+```bash
+# check-only (default): analyse DB and report issues
+combo-db-maint --json --no-files
+
+# fix: apply repairs and write before/after snapshots
+combo-db-maint --fix --output-dir .tmp_combo --json
+```
+
+Flags are unified across scripts: `--json`, `--no-files`, `--output-dir`,
+`--no-pretty`, `--debug-timings`. When files are written a RunLog manifest is
+emitted; adding `--debug-timings` also writes `timings.csv` and includes
+per-stage timings in the JSON summary.
+
 ## Repo Memory (Agent-Shared)
 
 Lightweight, auditable repo “memory” helps Cloud/CLI agents keep context across sessions.

--- a/docs/codex/COMBO_DB_MAINT_V1_2025-08-14_13-18_v1.md
+++ b/docs/codex/COMBO_DB_MAINT_V1_2025-08-14_13-18_v1.md
@@ -1,0 +1,11 @@
+# Combo DB Maintenance CLI
+
+## Candidates
+- V1: Simple audit/fix using existing combo helpers.
+- V2: Extend repair logic and timing instrumentation.
+
+## Chosen Version
+V1
+
+## Tests / Smokes
+- `pytest tests/test_combo_db_maint_cli.py`

--- a/portfolio_exporter/scripts/combo_db_maint.py
+++ b/portfolio_exporter/scripts/combo_db_maint.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+"""Audit and repair the combos DB."""
+
+import argparse
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+
+from portfolio_exporter.core import cli as cli_helpers
+from portfolio_exporter.core import json as json_helpers
+from portfolio_exporter.core import combo as combo_utils
+from portfolio_exporter.core.chain import get_combo_db_path
+from portfolio_exporter.core.io import migrate_combo_schema, save
+from portfolio_exporter.core.runlog import RunLog
+
+
+def _ensure_db(path: Path) -> Path:
+    """Ensure a combos DB exists; seed with a small sample when absent."""
+    if path.exists():
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE combos (
+            combo_id TEXT PRIMARY KEY,
+            structure TEXT,
+            underlying TEXT,
+            expiry TEXT,
+            type TEXT,
+            width REAL,
+            credit_debit REAL,
+            parent_combo_id TEXT,
+            closed_date TEXT
+        );
+        CREATE TABLE combo_legs (
+            combo_id TEXT,
+            conid INTEGER,
+            strike REAL,
+            right TEXT,
+            PRIMARY KEY(combo_id, conid)
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO combos (combo_id, structure, underlying, expiry, type, width, credit_debit) VALUES (?,?,?,?,?,?,?)",
+        [
+            ("1", "vertical", "AAPL", "2024-01-19", None, None, None),
+            ("2", None, "MSFT", "2024-02-16", "vertical", 10.0, 1.0),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO combo_legs (combo_id, conid, strike, right) VALUES (?,?,?,?)",
+        [("1", 1, 150, "C"), ("1", 2, 155, "P")],
+    )
+    migrate_combo_schema(conn)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _load_df(path: Path) -> pd.DataFrame:
+    conn = sqlite3.connect(path)
+    df = pd.read_sql("SELECT * FROM combos", conn)
+    conn.close()
+    return df
+
+
+def _analyse(df: pd.DataFrame) -> Dict[str, Any]:
+    broken_mask = df["underlying"].isna() | df["structure"].isna()
+    repair_mask = ~broken_mask & (
+        df[["type", "width", "credit_debit"]].isna().any(axis=1)
+    )
+    unknown_mask = ~(broken_mask | repair_mask)
+    return {
+        "broken_count": int(broken_mask.sum()),
+        "repairable_count": int(repair_mask.sum()),
+        "unknown_count": int(unknown_mask.sum()),
+        "broken_examples": df.loc[broken_mask, "combo_id"].head(3).tolist(),
+        "repairable_examples": df.loc[repair_mask, "combo_id"].head(3).tolist(),
+        "unknown_examples": df.loc[unknown_mask, "combo_id"].head(3).tolist(),
+    }
+
+
+def _fix_df(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    out.loc[out["structure"].isna(), "structure"] = "unknown"
+    out.loc[out["underlying"].isna(), "underlying"] = "UNKNOWN"
+    for col in ["type", "width", "credit_debit"]:
+        if col in out.columns:
+            if out[col].dtype == float:
+                out[col] = out[col].fillna(0.0)
+            else:
+                out[col] = out[col].fillna("unknown")
+    return out
+
+
+def _run_core(ns: argparse.Namespace, outdir: Path, formats: Dict[str, bool]) -> Dict[str, Any]:
+    db_path = _ensure_db(get_combo_db_path())
+    written: list[Path] = []
+    outputs = {"before": "", "after": ""}
+
+    with RunLog(script="combo_db_maint", args=vars(ns), output_dir=outdir) as rl:
+        if ns.fix:
+            df_before = _load_df(db_path)
+            stats_before = _analyse(df_before)
+            if formats["csv"]:
+                before_path = save(df_before, "combo_db_before", "csv", outdir)
+                outputs["before"] = str(before_path)
+                written.append(before_path)
+            with rl.time("repair"):
+                df_after = _fix_df(df_before)
+                conn = sqlite3.connect(db_path)
+                df_after.to_sql("combos", conn, if_exists="replace", index=False)
+                migrate_combo_schema(conn)
+                conn.close()
+            df = df_after
+        else:
+            df = _load_df(db_path)
+
+        with rl.time("analysis"):
+            stats = _analyse(df)
+
+        if ns.fix and formats["csv"]:
+            after_path = save(df, "combo_db_after", "csv", outdir)
+            outputs["after"] = str(after_path)
+            written.append(after_path)
+
+        sections = {
+            "broken": stats["broken_count"],
+            "repairable": stats["repairable_count"],
+            "unknown": stats["unknown_count"],
+        }
+        meta = {
+            "examples": {
+                "broken": stats["broken_examples"],
+                "repairable": stats["repairable_examples"],
+                "unknown": stats["unknown_examples"],
+            }
+        }
+        summary = json_helpers.report_summary(sections, outputs=outputs, meta=meta)
+
+        if ns.debug_timings:
+            summary.setdefault("meta", {})["timings"] = rl.timings
+            if written and formats["csv"]:
+                tpath = save(pd.DataFrame(rl.timings), "timings", "csv", outdir)
+                summary["outputs"].append(str(tpath))
+                written.append(tpath)
+
+        rl.add_outputs(written)
+        manifest = rl.finalize(write=bool(written))
+
+    if manifest:
+        summary["outputs"].append(str(manifest))
+    return summary
+
+
+def cli(ns: argparse.Namespace) -> Dict[str, Any]:
+    outdir = cli_helpers.resolve_output_dir(ns.output_dir)
+    formats = cli_helpers.decide_file_writes(ns, json_only_default=True, defaults={"csv": True})
+    return _run_core(ns, outdir, formats)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit/repair combos DB")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--no-files", action="store_true")
+    parser.add_argument("--output-dir")
+    parser.add_argument("--no-pretty", action="store_true")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check-only", action="store_true")
+    group.add_argument("--fix", action="store_true")
+    parser.add_argument("--debug-timings", action="store_true")
+    ns = parser.parse_args(argv)
+    if not ns.fix:
+        ns.check_only = True
+    summary = cli(ns)
+    if ns.json:
+        quiet, _ = cli_helpers.resolve_quiet(ns.no_pretty)
+        cli_helpers.print_json(summary, quiet)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ trades-report = "portfolio_exporter.scripts.trades_report:main"
 portfolio-greeks = "portfolio_exporter.scripts.portfolio_greeks:main"
 doctor = "portfolio_exporter.scripts.doctor:main"
 validate-json = "portfolio_exporter.scripts.validate_json:main"
+combo-db-maint = "portfolio_exporter.scripts.combo_db_maint:main"
 
 [tool.setuptools.packages.find]
 include = ["portfolio_exporter*"]

--- a/tests/test_combo_db_maint_cli.py
+++ b/tests/test_combo_db_maint_cli.py
@@ -1,0 +1,46 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+DB_PATH = Path("tmp_test_run/combos.db")
+
+
+def _run(args, tmp_path):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": ".", "PE_TEST_MODE": "1", "PE_OUTPUT_DIR": str(tmp_path)})
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+    return subprocess.run(
+        [sys.executable, "-m", "portfolio_exporter.scripts.combo_db_maint", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+
+
+def test_json_only(tmp_path):
+    result = _run(["--json", "--no-files"], tmp_path)
+    data = json.loads(result.stdout)
+    assert data["ok"]
+    assert set(data["sections"]).issuperset({"broken", "repairable"})
+    assert data["outputs"] == []
+
+
+def test_fix_writes_files(tmp_path):
+    result = _run(["--fix", "--output-dir", str(tmp_path), "--json", "--debug-timings"], tmp_path)
+    data = json.loads(result.stdout)
+    assert (tmp_path / "combo_db_before.csv").exists()
+    assert (tmp_path / "combo_db_after.csv").exists()
+    assert (tmp_path / "combo_db_maint_manifest.json").exists()
+    assert (tmp_path / "timings.csv").exists()
+    assert data["ok"]
+
+
+def test_idempotent(tmp_path):
+    _run(["--fix", "--output-dir", str(tmp_path), "--json"], tmp_path)
+    result = _run(["--json", "--no-files"], tmp_path)
+    data = json.loads(result.stdout)
+    assert data["sections"]["broken"] == 0

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -47,6 +47,11 @@ FIXTURES = Path("tests/data")
             False,
         ),
         ("portfolio_exporter.scripts.doctor", ["--json", "--no-files"], True),
+        (
+            "portfolio_exporter.scripts.combo_db_maint",
+            ["--json", "--no-files"],
+            False,
+        ),
     ],
 )
 def test_entrypoint_main_ok(mod_path, argv, needs_env, monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- add `combo-db-maint` utility to audit/repair combos DB with RunLog and optional fixes
- document maintenance workflow and wire up console entry
- cover new CLI with dedicated tests and codex log

## Testing
- `ruff check portfolio_exporter/scripts/combo_db_maint.py tests/test_combo_db_maint_cli.py tests/test_entrypoints.py`
- `pytest -q tests/test_combo_db_maint_cli.py tests/test_entrypoints.py`


------
https://chatgpt.com/codex/tasks/task_e_689de10a7fd8832e87679cf88a4557a9