### PR TITLE
Add dry-run previews for daily report and roll manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ doctor --json --no-files
 daily-report --json --no-files | validate-json
 ```
 
+## Menus
+
+The interactive menus now include quick previews that avoid writing files:
+
+```
+Trades & Reports › Preview Daily Report (JSON-only)
+Positions: 12
+Combos: 3
+Totals: 1
+Expiry radar: {...}
+
+Trades & Reports › Preview Roll Manager (dry-run)
+Candidates: 4
+TSLA Δ+1.20 +0.50
+AAPL Δ-0.80 -0.30
+```
+
 Typical fixes:
 
 ```bash

--- a/docs/codex/MENUS_DRYRUN_WIRING_V1_2025-08-29_12-03_v1.md
+++ b/docs/codex/MENUS_DRYRUN_WIRING_V1_2025-08-29_12-03_v1.md
@@ -1,0 +1,11 @@
+# Menus dry-run wiring v1
+
+Date: 2025-08-29 12:03 UTC
+
+## Candidates
+- Shell out to CLI scripts and parse JSON.
+- Call Python entrypoints directly and silence UI with `PE_QUIET`.
+
+## Decision
+Chose direct entrypoints with a temporary `PE_QUIET` override to avoid spinners.
+Added preview hooks for daily report and roll manager.

--- a/portfolio_exporter/menus/trade.py
+++ b/portfolio_exporter/menus/trade.py
@@ -16,14 +16,63 @@ import os
 
 def launch(status, default_fmt):
     console = status.console if status else Console()
+
+    def _preview_daily_report() -> None:
+        orig_quiet = os.getenv("PE_QUIET")
+        os.environ["PE_QUIET"] = "1"
+        try:
+            summary = daily_report.main(["--json", "--no-files"])
+        except Exception as exc:  # pragma: no cover - defensive
+            console.print(f"[red]Preview failed:[/] {exc}")
+        else:
+            sections = summary.get("sections", {})
+            console.print(f"Positions: {sections.get('positions', 0)}")
+            console.print(f"Combos: {sections.get('combos', 0)}")
+            console.print(f"Totals: {sections.get('totals', 0)}")
+            radar = summary.get("expiry_radar")
+            if radar:
+                console.print(f"Expiry radar: {radar}")
+            for w in summary.get("warnings", []):
+                console.print(f"[yellow]{w}")
+        finally:
+            if orig_quiet is None:
+                os.environ.pop("PE_QUIET", None)
+            else:
+                os.environ["PE_QUIET"] = orig_quiet
+
+    def _preview_roll_manager() -> None:
+        orig_quiet = os.getenv("PE_QUIET")
+        os.environ["PE_QUIET"] = "1"
+        try:
+            summary = roll_manager.cli(["--dry-run", "--json", "--no-files"])
+        except Exception as exc:  # pragma: no cover - defensive
+            console.print(f"[red]Preview failed:[/] {exc}")
+        else:
+            candidates = summary.get("candidates", [])
+            console.print(f"Candidates: {len(candidates)}")
+            top = sorted(candidates, key=lambda c: abs(c.get("delta", 0)), reverse=True)[:3]
+            for c in top:
+                console.print(
+                    f"{c.get('underlying')} Δ{c.get('delta', 0):+0.2f} {c.get('debit_credit', 0):+0.2f}"
+                )
+            for w in summary.get("warnings", []):
+                console.print(f"[yellow]{w}")
+        finally:
+            if orig_quiet is None:
+                os.environ.pop("PE_QUIET", None)
+            else:
+                os.environ["PE_QUIET"] = orig_quiet
+
     while True:
         entries = [
             ("e", "Executions / open orders"),
             ("b", "Build order"),
             ("l", "Roll positions"),
+            ("v", "Preview Roll Manager (dry-run)"),
             ("q", "Quick option chain"),
             ("n", "Net-Liq (CLI)"),
             ("d", "Daily report (HTML/PDF)"),
+            ("p", "Preview Daily Report (JSON-only)"),
             ("r", "Return"),
         ]
         tbl = Table(title="Trades & Reports")
@@ -46,6 +95,7 @@ def launch(status, default_fmt):
                 "e": lambda: trades_report.run(fmt=default_fmt, show_actions=True),
                 "b": order_builder.run,
                 "l": lambda: roll_manager.run(),
+                "v": _preview_roll_manager,
                 "q": lambda: option_chain_snapshot.run(fmt=default_fmt),
                 "n": lambda: net_liq_history_export.main(
                     ["--quiet", "--no-pretty"] if os.getenv("PE_QUIET") else []
@@ -53,6 +103,7 @@ def launch(status, default_fmt):
                 "d": lambda: daily_report.main(
                     ["--no-pretty"] if os.getenv("PE_QUIET") else []
                 ),
+                "p": _preview_daily_report,
             }.get(ch)
             if dispatch:
                 label = label_map.get(ch, ch)

--- a/tests/test_menus_preview.py
+++ b/tests/test_menus_preview.py
@@ -1,0 +1,76 @@
+import types
+import importlib.util
+import pathlib
+import sys
+import types
+import main
+
+# stub optional dependencies for import-time side effects
+sys.modules.setdefault("prompt_toolkit", types.SimpleNamespace(prompt=lambda *a, **k: ""))
+sys.modules.setdefault("dateparser", types.SimpleNamespace(parse=lambda *a, **k: None))
+sys.modules.setdefault(
+    "ib_insync",
+    types.SimpleNamespace(IB=object, Option=object, Stock=object),
+)
+
+spec = importlib.util.spec_from_file_location(
+    "trade", pathlib.Path("portfolio_exporter/menus/trade.py")
+)
+trade = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(trade)
+
+
+def test_preview_daily_report(monkeypatch, capsys):
+    summary = {
+        "sections": {"positions": 1, "combos": 2, "totals": 3},
+        "expiry_radar": {"window_days": 5, "basis": "positions", "rows": []},
+    }
+
+    def fake_main(args=None):
+        assert args == ["--json", "--no-files"]
+        return summary
+
+    monkeypatch.setattr("portfolio_exporter.scripts.daily_report.main", fake_main)
+
+    inputs = iter(["p", "r"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    status = types.SimpleNamespace(update=lambda *a, **k: None, console=main.console)
+
+    trade.launch(status, "csv")
+
+    out = capsys.readouterr().out
+    assert "Positions: 1" in out
+    assert "Combos: 2" in out
+    assert "Totals: 3" in out
+    assert "Expiry radar" in out
+
+
+def test_preview_roll_manager(monkeypatch, capsys):
+    summary = {
+        "sections": {"candidates": 4},
+        "candidates": [
+            {"underlying": "AAA", "delta": 0.1, "debit_credit": 0.5},
+            {"underlying": "BBB", "delta": -0.8, "debit_credit": -0.3},
+            {"underlying": "CCC", "delta": 0.5, "debit_credit": 0.1},
+            {"underlying": "DDD", "delta": 1.2, "debit_credit": 0.2},
+        ],
+    }
+
+    def fake_cli(args=None):
+        assert args == ["--dry-run", "--json", "--no-files"]
+        return summary
+
+    monkeypatch.setattr("portfolio_exporter.scripts.roll_manager.cli", fake_cli)
+
+    inputs = iter(["v", "r"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    status = types.SimpleNamespace(update=lambda *a, **k: None, console=main.console)
+
+    trade.launch(status, "csv")
+
+    out = capsys.readouterr().out
+    assert "Candidates: 4" in out
+    # Sorted by absolute delta: DDD (1.2), BBB (0.8), CCC (0.5)
+    assert "DDD Δ+1.20 +0.20" in out
+    assert "BBB Δ-0.80 -0.30" in out
+    assert "CCC Δ+0.50 +0.10" in out


### PR DESCRIPTION
## Summary
- add preview options to Trades menu for daily report and roll manager
- document preview usage in README and codex
- add tests covering preview summaries

## Testing
- `make lint`
- `pytest -q tests/test_menus_preview.py`
- `make memory-validate` *(fails: No module named portfolio_exporter.scripts.memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1963f12c4832ea76b987ef167fd07