### PR TITLE
feat(trades): prior-snapshot intent tagging + attribute fallback + --debug-intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ timings data in the JSON summary.
 
 ### Trades Report
 
+Note: Intent tagging prefers a positions snapshot strictly older than the earliest execution in your selected window to decide whether combos are Open, Close, Mixed, or Roll. Use `--debug-intent` to emit `trades_intent_debug.csv` with per‑leg matching details. If no prior snapshot exists, tagging falls back to the latest positions and accuracy may decrease.
+
 Examples with date filters and summaries:
 
 ```bash


### PR DESCRIPTION
This improves intent tagging in trades_report by preferring a strictly prior positions snapshot, adding an attribute-based fallback when synthetic leg IDs do not match, and exposing an optional debug artifact.

Key changes
- Prefer strictly prior snapshot: selects the latest `portfolio_greeks_positions*.csv` whose mtime is strictly older than the earliest execution timestamp in the filtered window. Falls back to the latest snapshot when none is strictly prior, and emits a JSON warning.
- Attribute fallback: when leg ID lookup fails, matches by (underlying, normalized expiry, right, strike within ±0.01) to detect presence in prior positions.
- Window-accurate deltas: prior reconstruction (`prior = after - delta`) uses only the executions filtered by the CLI window.
- Debug flag: `--debug-intent` writes `trades_intent_debug.csv` with per-leg matching details (combo_sig, underlying, expiry, right, strike, match_mode, prior_qty, leg_effect). Aggregated counters are added to `trades_combos.csv` (legs_open_count, legs_close_count, legs_match_id_count, legs_match_attr_count).
- JSON warning: if no strictly-prior snapshot exists, the summary includes: "No prior positions snapshot found before earliest execution; intent may be less accurate."
- README note under "Trades Report" documenting the above and `--debug-intent`.

Offline-first: no new dependencies, network calls, or behavioral changes unless `--debug-intent` is passed.

Smokes (local examples)
- JSON-only shape:
  `PE_QUIET=1 python -m portfolio_exporter.scripts.trades_report \
   --executions-csv /mnt/data/trades_report_20250829_2000.csv \
   --since 2025-08-29T00:00 --until 2025-08-29T23:59 \
   --json --no-files | jq '.warnings, .sections'`
- Files + debug:
  `OUT=.tmp_trades_intent && \
   python -m portfolio_exporter.scripts.trades_report \
   --executions-csv /mnt/data/trades_report_20250829_2000.csv \
   --since 2025-08-29T00:00 --until 2025-08-29T23:59 \
   --output-dir "$OUT" --json --debug-intent >/dev/null && \
   ls "$OUT" | grep -E 'trades_(report|combos).*\\.csv|trades_intent_debug\\.csv'`

Scope: Only `portfolio_exporter/scripts/trades_report.py` and `README.md` modified.
