### PR TITLE
fix(trades): prior-snapshot selection + attribute fallback + --debug-intent & revert main.py helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ timings data in the JSON summary.
 
 ### Trades Report
 
+Note: Intent tagging prefers a positions snapshot strictly older than the earliest execution in your selected window to decide whether combos are Open, Close, Mixed, or Roll. Use `--debug-intent` to emit `trades_intent_debug.csv` with per‑leg matching details. If no prior snapshot exists, tagging falls back to the latest positions and accuracy may decrease.
+
 Examples with date filters and summaries:
 
 ```bash


### PR DESCRIPTION
This surgically fixes intent tagging and keeps menus fast.

Summary
- Revert: no intent helpers in main.py; all logic stays in scripts/trades_report.py.
- Prior snapshot: choose the latest `portfolio_greeks_positions*.csv` strictly older than earliest execution in the filtered window; parse timestamp from filename (YYYYMMDD_HHMM) or fall back to mtime.
- Timestamps: robust UTC parsing helpers; guard against NaT.
- Attribute fallback: when leg-ID hash fails, match by (underlying, normalized expiry, right, strike±0.01) to decide Close/Open.
- Window-accurate: any delta reconstruction uses only the already-filtered executions.
- Debug: `--debug-intent` emits `trades_intent_debug.csv` with per-leg rows (combo_sig, underlying, expiry, right, strike, prior_qty, match_mode, leg_effect). Also adds per-combo counters (match-id/attr/open/close).
- Warning: if no strictly-prior snapshot exists, JSON summary includes a warning and gracefully falls back to the latest snapshot.

Offline-first: no new dependencies or network calls. Menus remain unchanged.

Validation (local)
- JSON-only shape (no files):
```
PE_QUIET=1 python -m portfolio_exporter.scripts.trades_report \
  --executions-csv /mnt/data/trades_report_20250829_2026.csv \
  --since 2025-08-29T00:00 --until 2025-08-29T23:59 \
  --json --no-files | jq '.warnings, .sections'
```
- Files + debug CSV + manifest:
```
OUT=.tmp_trades_intent
python -m portfolio_exporter.scripts.trades_report \
  --executions-csv /mnt/data/trades_report_20250829_2026.csv \
  --since 2025-08-29T00:00 --until 2025-08-29T23:59 \
  --output-dir "$OUT" --json --debug-intent >/dev/null
ls "$OUT" | grep -E 'trades_(report|combos).*\\.csv|trades_intent_debug\\.csv|_manifest\\.json'
```
