### PR TITLE
fix: serve last-good PSD stats outside RTH

### DIFF
--- a/apps/web/src/components/__tests__/StatsRibbon.outOfRth.test.tsx
+++ b/apps/web/src/components/__tests__/StatsRibbon.outOfRth.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import StatsRibbon from "../StatsRibbon";
 import { buildPsdSnapshot, buildStatsResponse } from "../../mocks/handlers";
@@ -35,7 +35,6 @@ describe("StatsRibbon out of RTH", () => {
       session_info: null,
     });
     expect(statsPayload.session?.state).toBe("ETH");
-    // console.log("stats session state", statsPayload.session?.state);
 
     const snapshotFixture = buildPsdSnapshot();
     const view = snapshotFixture.positions_view;

--- a/apps/web/src/hooks/useStats.ts
+++ b/apps/web/src/hooks/useStats.ts
@@ -1,5 +1,10 @@
 import { useEffect } from "react";
-import { useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+  type DefaultError,
+} from "@tanstack/react-query";
 
 import type { PortfolioStats, PortfolioStatsApiResponse } from "../lib/types";
 import { normalizeSession } from "../lib/session";
@@ -129,7 +134,9 @@ export const fetchStats = async (baseUrl = ""): Promise<PortfolioStats> => {
   return parseStatsPayload(payload ?? null);
 };
 
-export function useStats(baseUrl?: string): UseQueryResult<PortfolioStats, Error> {
+export function useStats(
+  baseUrl?: string,
+): UseQueryResult<PortfolioStats, DefaultError> {
   const queryClient = useQueryClient();
   const resolvedBaseUrl = resolveBaseUrl(baseUrl ?? "");
 
@@ -146,10 +153,48 @@ export function useStats(baseUrl?: string): UseQueryResult<PortfolioStats, Error
       try {
         const data = event.data ? JSON.parse(event.data) : null;
         const parsed = parseStatsPayload(data);
-        queryClient.setQueryData(PSD_STATS_QUERY_KEY, (current) => ({
-          ...current,
-          ...parsed,
-        }));
+        const raw = (data && typeof data === "object" ? data : null) as
+          | Record<string, unknown>
+          | null;
+        queryClient.setQueryData(PSD_STATS_QUERY_KEY, (current) => {
+          if (!current) {
+            return parsed;
+          }
+
+          const mergedCounts = current.counts
+            ? { ...current.counts }
+            : { ...parsed.counts };
+
+          if (raw) {
+            if ("equity_count" in raw) {
+              mergedCounts.equities = parsed.counts.equities;
+            }
+            if ("quote_count" in raw) {
+              mergedCounts.quotes = parsed.counts.quotes;
+            }
+            if ("option_legs_count" in raw) {
+              mergedCounts.optionLegs = parsed.counts.optionLegs;
+            }
+            if ("combos_matched" in raw) {
+              mergedCounts.combos = parsed.counts.combos;
+            }
+            if ("stale_quotes_count" in raw) {
+              mergedCounts.staleQuotes = parsed.counts.staleQuotes;
+            }
+            if ("rules_count" in raw) {
+              mergedCounts.rules = parsed.counts.rules;
+            }
+            if ("breaches_count" in raw) {
+              mergedCounts.breaches = parsed.counts.breaches;
+            }
+          }
+
+          return {
+            ...current,
+            ...parsed,
+            counts: mergedCounts,
+          };
+        });
       } catch (error) {
         if (import.meta.env?.DEV) {
           // eslint-disable-next-line no-console -- useful for diagnosing malformed payloads.

--- a/src/psd/README.md
+++ b/src/psd/README.md
@@ -22,13 +22,13 @@
 ## API Surfaces
 - `GET /psd` returns the compiled dashboard; other static assets flow from `apps/web/dist`.
 - `GET /stream` emits server-sent events (bootstrap snapshot, then diffs and breaches) for the UI and automation hooks.
-- `GET /sse` streams lightweight events (currently `msb.update`) with heartbeats for automation consumers.
+- `GET /sse` streams lightweight events (`msb.update`, `psd.stats.update`) with heartbeats for automation consumers.
 - `GET /state`, `/positions/stocks`, `/positions/options`, and `/session` return normalized portfolio state.
 - `GET /stats/current` returns the last-good portfolio stats regardless of trading session; append `?fresh_within_sec=N` to require freshness in seconds.
 - `GET /rules/summary`, `/rules/catalog`, and `/metrics` surface sentinel findings and Prometheus counters.
 - `GET /msb/current` and `/msb/history?days=N` expose the Market Stress Barometer as JSON for dashboards and scripts.
 - `POST /msb/broadcast` triggers an `msb.update` SSE when the latest reading is available (used by the `msb_emit` CLI).
-- `/metrics` exports Prometheus counters including `psd_msb_scheduler_runs_total`, `psd_msb_alerts_total{rule}`, `psd_livebar_rows_total`, and `psd_stats_startup_broadcasts_total` for observability of the MSB pipeline.
+- `/metrics` exports Prometheus counters including `psd_msb_scheduler_runs_total`, `psd_msb_alerts_total{rule}`, `psd_livebar_rows_total`, `psd_stats_startup_broadcasts_total`, and `psd_stats_broadcasts_total{trigger}` for observability of the MSB pipeline.
 - Standard FastAPI metadata endpoints (`/docs`, `/openapi.json`) remain available for interactive exploration.
 
 ## MSB Scheduler & Live Bar

--- a/src/psd/web/app.py
+++ b/src/psd/web/app.py
@@ -47,6 +47,11 @@ STATS_STARTUP_BROADCASTS = Counter(
     "psd_stats_startup_broadcasts_total",
     "Initial stats broadcasts emitted during application startup",
 )
+STATS_BROADCASTS = Counter(
+    "psd_stats_broadcasts_total",
+    "Portfolio stats SSE broadcasts emitted",
+    ["trigger"],
+)
 
 router = APIRouter()
 
@@ -83,7 +88,7 @@ def _create_lifespan(settings: Settings) -> Any:
         init()
         start_msb_scheduler(_app)
         try:
-            if broadcast_latest_stats(_app):
+            if broadcast_latest_stats(_app, trigger="startup"):
                 STATS_STARTUP_BROADCASTS.inc()
         except Exception:
             log.debug("initial stats broadcast failed", exc_info=True)
@@ -374,13 +379,13 @@ def broadcast_latest_msb(app: FastAPI) -> bool:
     dto = MsbDTO.model_validate(record).model_dump(mode="json")
     manager.broadcast("msb.update", dto)
     try:
-        broadcast_latest_stats(app)
+        broadcast_latest_stats(app, trigger="msb")
     except Exception:  # pragma: no cover - defensive logging path
         log.debug("stats broadcast after msb update failed", exc_info=True)
     return True
 
 
-def broadcast_latest_stats(app: FastAPI) -> bool:
+def broadcast_latest_stats(app: FastAPI, *, trigger: str = "manual") -> bool:
     manager = getattr(app.state, "sse", None)
     if not isinstance(manager, SseManager):
         raise RuntimeError("SSE manager not attached to FastAPI application")
@@ -388,6 +393,11 @@ def broadcast_latest_stats(app: FastAPI) -> bool:
     if payload is None:
         return False
     manager.broadcast("psd.stats.update", payload)
+    try:
+        label = str(trigger or "manual")
+    except Exception:  # pragma: no cover - extremely defensive
+        label = "manual"
+    STATS_BROADCASTS.labels(trigger=label).inc()
     return True
 
 

--- a/tests/test_psd_stats_out_of_rth.py
+++ b/tests/test_psd_stats_out_of_rth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from prometheus_client import REGISTRY
 
 from psd.core import store
 from psd.web.app import broadcast_latest_stats, create_app
@@ -96,6 +97,10 @@ def test_broadcast_latest_stats_emits_event(tmp_db, monkeypatch: pytest.MonkeyPa
         events.append((event_type, payload))
 
     monkeypatch.setattr(app.state.sse, "broadcast", _capture)
+    before = REGISTRY.get_sample_value(
+        "psd_stats_broadcasts_total",
+        {"trigger": "manual"},
+    ) or 0.0
     broadcasted = broadcast_latest_stats(app)
 
     assert broadcasted is True
@@ -104,3 +109,8 @@ def test_broadcast_latest_stats_emits_event(tmp_db, monkeypatch: pytest.MonkeyPa
     assert event_name == "psd.stats.update"
     assert payload["staleness_sec"] >= 0
     assert payload["day_pnl"] == pytest.approx(1250.5)
+    after = REGISTRY.get_sample_value(
+        "psd_stats_broadcasts_total",
+        {"trigger": "manual"},
+    ) or 0.0
+    assert after == pytest.approx(before + 1.0)


### PR DESCRIPTION
## Summary
- emit `psd.stats.update` on startup and MSB refreshes while recording a broadcast counter
- reuse `read_last_stats` for `/stats/current` responses and exercise the flow with backend tests
- stream the payload via `/sse` to the web app, keeping ribbon metrics during ETH with new unit coverage and docs

## Testing
- ruff check .
- PE_TEST_MODE=1 pytest
- pnpm vitest run --project unit

------
https://chatgpt.com/codex/tasks/task_e_68fba6b5deec832eaade2d5ca5768b5a